### PR TITLE
ci: remove unnecessary Buildx setup from manifest verify

### DIFF
--- a/.github/workflows/verify-published-manifest.yml
+++ b/.github/workflows/verify-published-manifest.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Verify published manifest
         run: ./scripts/check-manifest.sh "${{ matrix.image_ref }}"
 
@@ -44,9 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Verify published manifest
         run: ./scripts/check-manifest.sh "${{ inputs.image_ref }}"


### PR DESCRIPTION
## Summary
- remove Docker Buildx setup from the manifest verification workflow
- keep the workflow focused on `docker buildx imagetools inspect`, which does not require bootstrapping a docker-container builder
- avoid transient failures while pulling `moby/buildkit:buildx-stable-1`

## Validation
- parsed `.github/workflows/verify-published-manifest.yml` as YAML
- ran `./scripts/check-manifest.sh` for `woosungchoi/fpm-alpine:8.0` through `8.5`; all passed for `linux/amd64` and `linux/arm64`

## Rollback
- re-add the two `docker/setup-buildx-action@v3` steps if this workflow unexpectedly requires a bootstrapped builder later
