### PR TITLE
ci: improve Docker Hub publish visibility

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,13 +17,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image for smoke test
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/verify-published-manifest.yml
+++ b/.github/workflows/verify-published-manifest.yml
@@ -1,6 +1,14 @@
 name: verify-published-manifest
 
 on:
+  push:
+    branches:
+      - '8.0'
+      - '8.1'
+      - '8.2'
+      - '8.3'
+      - '8.4'
+      - '8.5'
   schedule:
     - cron: '17 3 * * *'
   workflow_dispatch:
@@ -28,10 +36,19 @@ jobs:
           - woosungchoi/fpm-alpine:8.5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify published manifest
-        run: ./scripts/check-manifest.sh "${{ matrix.image_ref }}"
+        env:
+          IMAGE_REF: ${{ matrix.image_ref }}
+        run: ./scripts/report-manifest.sh "$IMAGE_REF"
+
+      - name: Upload manifest report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: manifest-report-${{ strategy.job-index }}
+          path: manifest-reports/
 
   verify-single-input:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.image_ref != '' }}
@@ -40,7 +57,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify published manifest
-        run: ./scripts/check-manifest.sh "${{ inputs.image_ref }}"
+        env:
+          IMAGE_REF: ${{ inputs.image_ref }}
+        run: ./scripts/report-manifest.sh "$IMAGE_REF"
+
+      - name: Upload manifest report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: manifest-single-input
+          path: manifest-reports/

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ For the full policy and operational notes, see [BRANCH-AND-TAG-POLICY.md](./BRAN
 
 ## Maintenance and security status
 
+### Published manifest verification reports
+
+Docker Hub hooks remain the publishing path for this repository. GitHub Actions now provides the visibility layer around that publish path:
+
+- `verify-published-manifest` runs after maintained-branch pushes, on a daily schedule, and on manual dispatch.
+- The workflow verifies each maintained Docker Hub tag for the expected `linux/amd64` and `linux/arm64` platforms.
+- Each run writes a GitHub Actions step summary and uploads manifest report artifacts containing the observed tag digest, per-platform digests, and attestation/metadata manifest entries when present.
+- Branch-push runs make the current published Docker Hub state visible from GitHub Actions. Docker Hub autobuild can still lag behind the GitHub push, so the daily/manual verification remains the source of truth for the final published state.
+
+This keeps Docker Hub autobuild hooks in place while making the final published image state easier to inspect from GitHub Actions.
+
 This repository is maintained through version branches and lightweight verification workflows:
 
 - `smoke-test` builds the branch Dockerfile and validates PHP/FPM runtime basics, required extensions, `ffmpeg`, `iconv`, and `Imagick` behavior.

--- a/scripts/report-manifest.sh
+++ b/scripts/report-manifest.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_REF="${1:-}"
+shift || true
+EXPECTED_PLATFORMS=("$@")
+
+if [ -z "$IMAGE_REF" ]; then
+  echo "usage: $0 <registry-image-ref> [expected-platform ...]" >&2
+  exit 64
+fi
+
+if [ ${#EXPECTED_PLATFORMS[@]} -eq 0 ]; then
+  EXPECTED_PLATFORMS=(linux/amd64 linux/arm64)
+fi
+
+safe_name="${IMAGE_REF//[^A-Za-z0-9_.-]/_}"
+report_dir="${MANIFEST_REPORT_DIR:-manifest-reports}"
+mkdir -p "$report_dir"
+raw_file="$report_dir/${safe_name}.raw.json"
+json_file="$report_dir/${safe_name}.summary.json"
+md_file="$report_dir/${safe_name}.md"
+
+inspect_text="$(docker buildx imagetools inspect "$IMAGE_REF")"
+digest="$(awk '/^Digest:/ { print $2; exit }' <<< "$inspect_text")"
+if [ -z "$digest" ]; then
+  echo "failed to resolve digest for $IMAGE_REF" >&2
+  exit 1
+fi
+
+docker buildx imagetools inspect --raw "$IMAGE_REF" > "$raw_file"
+
+parser_file="$(mktemp)"
+trap 'rm -f "$parser_file"' EXIT
+cat > "$parser_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+image_ref = sys.argv[1]
+digest = sys.argv[2]
+json_file = Path(sys.argv[3])
+md_file = Path(sys.argv[4])
+expected = sys.argv[5:]
+manifest = json.load(sys.stdin)
+
+platforms = []
+attestations = []
+for item in manifest.get("manifests", []):
+    platform = item.get("platform") or {}
+    os_name = platform.get("os")
+    arch = platform.get("architecture")
+    variant = platform.get("variant")
+    annotations = item.get("annotations") or {}
+    media_type = item.get("mediaType", "")
+    item_digest = item.get("digest", "")
+
+    if os_name == "unknown" or arch == "unknown":
+        attestations.append({
+            "digest": item_digest,
+            "mediaType": media_type,
+            "referenceDigest": annotations.get("vnd.docker.reference.digest"),
+            "referenceType": annotations.get("vnd.docker.reference.type"),
+        })
+        continue
+
+    if os_name and arch:
+        base_value = f"{os_name}/{arch}"
+        value = base_value
+        if variant:
+            value = f"{value}/{variant}"
+        platforms.append({"platform": value, "digest": item_digest, "mediaType": media_type})
+
+found = {item["platform"] for item in platforms}
+for item in platforms:
+    parts = item["platform"].split("/")
+    if len(parts) == 3:
+        found.add("/".join(parts[:2]))
+missing = [item for item in expected if item not in found]
+summary = {
+    "image": image_ref,
+    "digest": digest,
+    "expectedPlatforms": expected,
+    "platforms": sorted(platforms, key=lambda item: item["platform"]),
+    "missingPlatforms": missing,
+    "attestations": attestations,
+}
+json_file.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+lines = [
+    f"## `{image_ref}`",
+    "",
+    f"- Digest: `{digest}`",
+    f"- Expected platforms: {', '.join(f'`{item}`' for item in expected)}",
+    f"- Status: {'✅ passed' if not missing else '❌ missing ' + ', '.join(missing)}",
+    "",
+    "### Platforms",
+    "",
+]
+for item in summary["platforms"]:
+    lines.append(f"- `{item['platform']}` — `{item['digest']}`")
+if attestations:
+    lines.extend(["", "### Attestation/metadata manifest entries", ""])
+    for item in attestations:
+        ref = item.get("referenceDigest") or "unknown reference"
+        rtype = item.get("referenceType") or "unknown type"
+        lines.append(f"- `{rtype}` for `{ref}` — `{item.get('digest')}`")
+lines.append("")
+md_file.write_text("\n".join(lines))
+
+if missing:
+    print(f"missing manifest platform(s) for {image_ref}: {', '.join(missing)}", file=sys.stderr)
+    print(f"manifest platforms present: {', '.join(sorted(found))}", file=sys.stderr)
+else:
+    print(f"manifest report passed for {image_ref}: {', '.join(expected)}")
+print(f"digest: {digest}")
+PY
+python3 "$parser_file" "$IMAGE_REF" "$digest" "$json_file" "$md_file" "${EXPECTED_PLATFORMS[@]}" < "$raw_file"
+rm -f "$parser_file"
+
+cat "$md_file"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$md_file" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+missing_count="$(python3 - "$json_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+summary = json.loads(Path(sys.argv[1]).read_text())
+print(len(summary.get("missingPlatforms") or []))
+PY
+)"
+if [ "$missing_count" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- keep Docker Hub hooks unchanged as the publishing path
- add manifest report script with observed tag digest, platform digests, and attestation metadata
- run published-manifest verification after maintained branch pushes, on schedule, and on manual dispatch
- upload manifest report artifacts and write GitHub Actions step summaries
- update workflow actions to Node 24-compatible major versions

## Validation
- PyYAML parsed workflow files
- actionlint .github/workflows/*.yml
- bash -n scripts/check-manifest.sh scripts/smoke-test-image.sh scripts/report-manifest.sh hooks/build hooks/push
- scripts/report-manifest.sh succeeded for Docker Hub tags 8.0 through 8.5
- git diff --check
- verified hooks/build and hooks/push are unchanged
- static scan passed
- independent reviewer passed