### PR TITLE
ci: add authless operations guardrails

### DIFF
--- a/.github/workflows/branch-drift.yml
+++ b/.github/workflows/branch-drift.yml
@@ -1,0 +1,37 @@
+name: branch-drift
+
+on:
+  schedule:
+    - cron: '23 5 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: branch-drift-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout maintained branches
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch maintained branch refs
+        run: |
+          git fetch origin 8.0 8.1 8.2 8.3 8.4 8.5 --prune
+
+      - name: Generate branch drift report
+        run: ./scripts/branch-drift-report.sh
+
+      - name: Upload branch drift report
+        if: always()
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: branch-drift-report
+          path: branch-drift-reports/

--- a/.github/workflows/dependency-freshness.yml
+++ b/.github/workflows/dependency-freshness.yml
@@ -24,6 +24,10 @@ jobs:
         uses: docker/setup-buildx-action@v4.1.0
 
       - name: Generate dependency freshness report
+        env:
+          REPORT_DIR: freshness-reports
+          PHP_TAGS: "8.0 8.1 8.2 8.3 8.4 8.5"
+          PECL_PACKAGES: "imagick redis apcu"
         run: ./scripts/report-freshness.sh
 
       - name: Upload dependency freshness report

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -38,8 +38,20 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run smoke test
+        env:
+          SMOKE_REPORT_DIR: smoke-reports
         run: ./scripts/smoke-test-image.sh fpm-alpine:smoke
+
+      - name: Upload smoke report
+        if: always()
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: smoke-report
+          path: smoke-reports/
 
       - name: Inspect published multi-arch manifest (optional)
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.manifest_image != '' }}
+        env:
+          MANIFEST_RETRY_ATTEMPTS: "3"
+          MANIFEST_RETRY_DELAY_SECONDS: "20"
         run: ./scripts/check-manifest.sh "${{ inputs.manifest_image }}"

--- a/.github/workflows/verify-published-manifest.yml
+++ b/.github/workflows/verify-published-manifest.yml
@@ -26,7 +26,7 @@ jobs:
   verify-maintained-tags:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.image_ref == '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     permissions:
       contents: read
     strategy:
@@ -46,6 +46,8 @@ jobs:
       - name: Verify published manifest
         env:
           IMAGE_REF: ${{ matrix.image_ref }}
+          MANIFEST_RETRY_ATTEMPTS: "5"
+          MANIFEST_RETRY_DELAY_SECONDS: "20"
         run: ./scripts/report-manifest.sh "$IMAGE_REF"
 
       - name: Upload manifest report
@@ -58,7 +60,7 @@ jobs:
   verify-single-input:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.image_ref != '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     permissions:
       contents: read
     steps:
@@ -68,6 +70,8 @@ jobs:
       - name: Verify published manifest
         env:
           IMAGE_REF: ${{ inputs.image_ref }}
+          MANIFEST_RETRY_ATTEMPTS: "5"
+          MANIFEST_RETRY_DELAY_SECONDS: "20"
         run: ./scripts/report-manifest.sh "$IMAGE_REF"
 
       - name: Upload manifest report

--- a/BRANCH-AND-TAG-POLICY.md
+++ b/BRANCH-AND-TAG-POLICY.md
@@ -87,6 +87,12 @@ The repository-side policy is now:
 - treat `8.5` as the mainline in docs and internal references
 - avoid new work on legacy PHP 7.4 history
 - treat PHP 7.4 as frozen / unsupported here
+- keep Docker Hub hooks as the publish path; use GitHub Actions for verification, observation, and report-only guardrails
+- keep `docker-smoke` as the required branch-protection check, while manifest/freshness/drift workflows remain non-required reports
+
+## CI / operations runbook
+
+See [docs/ci-operations.md](./docs/ci-operations.md) for the maintained branch protection model, workflow triage steps, report-only workflow policy, and rollback procedure.
 
 
 ## Maintained Imagick baseline

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Custom PHP-FPM Alpine images used for WordPress / Gnuboard / Rhymix deployments.
 
-See also: [BRANCH-AND-TAG-POLICY.md](./BRANCH-AND-TAG-POLICY.md)
+See also: [BRANCH-AND-TAG-POLICY.md](./BRANCH-AND-TAG-POLICY.md) and [docs/ci-operations.md](./docs/ci-operations.md).
 
 > [!IMPORTANT]
 > This repository's **actively supported image lines** are the version branches **`8.0` through `8.5`**.
@@ -92,6 +92,7 @@ This repository is maintained through version branches and lightweight verificat
 - `smoke-test` builds the branch Dockerfile and validates PHP/FPM runtime basics, required extensions, `ffmpeg`, `iconv`, and `Imagick` behavior.
 - `verify-published-manifest` runs on a schedule and verifies the published Docker Hub tags for maintained branches.
 - `dependency-freshness` produces report-only dependency/source freshness observations for maintainers.
+- `branch-drift` produces report-only workflow/script/policy drift reports across maintained branches.
 - Maintained branches use the documented Imagick baseline in [BRANCH-AND-TAG-POLICY.md](./BRANCH-AND-TAG-POLICY.md).
 - Security reporting and supported-version policy are documented in [SECURITY.md](./SECURITY.md).
 

--- a/docs/branch-drift-allowlist.tsv
+++ b/docs/branch-drift-allowlist.tsv
@@ -1,0 +1,11 @@
+path	branch	reason
+Dockerfile	8.0	Expected PHP base-image line differs by maintained PHP version branch; imagick baseline should remain aligned unless documented otherwise.
+Dockerfile	8.1	Expected PHP base-image line differs by maintained PHP version branch; imagick baseline should remain aligned unless documented otherwise.
+Dockerfile	8.2	Expected PHP base-image line differs by maintained PHP version branch; imagick baseline should remain aligned unless documented otherwise.
+Dockerfile	8.3	Expected PHP base-image line differs by maintained PHP version branch; imagick baseline should remain aligned unless documented otherwise.
+Dockerfile	8.4	Expected PHP base-image line differs by maintained PHP version branch; imagick baseline should remain aligned unless documented otherwise.
+README.md	8.0	Version-branch README may intentionally describe its own branch while sharing the same support policy.
+README.md	8.1	Version-branch README may intentionally describe its own branch while sharing the same support policy.
+README.md	8.2	Version-branch README may intentionally describe its own branch while sharing the same support policy.
+README.md	8.3	Version-branch README may intentionally describe its own branch while sharing the same support policy.
+README.md	8.4	Version-branch README may intentionally describe its own branch while sharing the same support policy.

--- a/docs/ci-operations.md
+++ b/docs/ci-operations.md
@@ -1,0 +1,152 @@
+# CI operations runbook
+
+This runbook explains how `woosungchoi/fpm-alpine` uses GitHub Actions around the existing Docker Hub publish flow.
+
+## One-screen summary
+
+- Default branch: `8.5`
+- Maintained branches: `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5`
+- Legacy `master` / PHP 7.4: not active
+- Docker Hub hooks remain the publish path. GitHub Actions verifies, observes, and reports; it does not replace Docker Hub publishing.
+- Production users should pin explicit image tags such as `woosungchoi/fpm-alpine:8.5`.
+
+## Required status check
+
+The branch protection required check for maintained branches is the `smoke-test` workflow job named:
+
+- `docker-smoke`
+
+This is the only check that should block regular PR merges by default because it builds the branch Dockerfile and runs runtime checks in the built container.
+
+Non-required / report-only workflows:
+
+- `verify-published-manifest`
+  - Observes already-published Docker Hub tags.
+  - Can be affected by Docker Hub propagation or registry/network latency.
+- `dependency-freshness`
+  - Report-only dependency/source freshness observations.
+  - Does not mutate Dockerfiles, open PRs, or publish images.
+- `branch-drift`
+  - Report-only maintained-branch drift detection.
+  - Does not sync branches automatically.
+
+## Workflow responsibilities
+
+### `smoke-test`
+
+Purpose: PR/push build validation.
+
+Checks:
+
+- `php -v`
+- `php -m`
+- `php-fpm -t`
+- extension loading for `imagick`, `redis`, `apcu`
+- `ffmpeg`
+- `iconv` runtime behavior
+- `Imagick` class instantiation
+
+Triage:
+
+1. Open the failed `docker-smoke` job.
+2. Find the named smoke check that failed.
+3. If `php-fpm -t` failed, inspect the `php-fpm` config error and the emitted `/tmp/php-fpm.log` section.
+4. If an extension failed, first check Dockerfile extension install/build logs for that extension.
+5. If `iconv` failed, reassess the `gnu-libiconv` / `LD_PRELOAD` workaround on that branch only.
+
+Rollback:
+
+- Revert only the Dockerfile/script/workflow change that caused the smoke failure.
+- Do not change Docker Hub hooks to fix a GitHub Actions smoke failure.
+
+### `verify-published-manifest`
+
+Purpose: Observe Docker Hub-published multi-arch manifests.
+
+Expected platforms:
+
+- `linux/amd64`
+- `linux/arm64`
+
+Triage:
+
+1. Check whether the failure happened immediately after a GitHub push.
+2. If yes, suspect Docker Hub propagation lag first.
+3. Re-run the workflow manually with the same image ref after Docker Hub finishes publishing.
+4. If the tag still fails, inspect Docker Hub build/publish logs and the generated manifest report artifact.
+5. Only change publish logic after repeated manual checks prove the manifest is genuinely missing or malformed.
+
+Rollback:
+
+- GitHub Actions manifest verification can be reverted independently.
+- Docker Hub hooks remain the publish path and should not be replaced as a rollback shortcut.
+
+### `dependency-freshness`
+
+Purpose: Report dependency freshness without automatic mutation.
+
+The report includes:
+
+- Dockerfile base image digest
+- maintained Docker Hub tag digests
+- PECL latest observations for `imagick`, `redis`, and `apcu`
+- installed package signals parsed from the Dockerfile
+- `gnu-libiconv` workaround status
+- manual follow-up guidance
+
+Triage:
+
+1. Treat image `inspect_failed` as an observation, not an immediate CI failure.
+2. Treat PECL latest changes as manual review prompts.
+3. Keep `imagick-3.8.1` unless branch-specific smoke validation proves a different version is safe.
+4. Do not automatically update Dockerfiles from freshness output.
+
+Rollback:
+
+- Revert report formatting or parsing changes only.
+- No published images or dependency pins are changed by this workflow.
+
+### `branch-drift`
+
+Purpose: Detect missing workflow/script/policy changes across maintained branches.
+
+Triage:
+
+1. Review `branch-drift-reports/branch-drift.md`.
+2. Ignore `allowed-drift` only if the allowlist reason still matches current policy.
+3. For unexpected `drift`, manually inspect the file difference before syncing.
+4. Open an explicit PR for any branch sync; do not auto-merge branch-wide drift fixes.
+
+Rollback:
+
+- Disable or revert the `branch-drift` workflow if it is noisy.
+- Keep the allowlist narrow and reasoned.
+
+## Merge checklist
+
+Before merging CI/workflow changes:
+
+- `docker-smoke` passes on the PR branch.
+- Workflow YAML has explicit minimal permissions.
+- Report-only workflows are not marked as required checks.
+- Docker Hub publish hooks are unchanged unless the task is explicitly a publish migration.
+- README, branch policy, and this runbook agree on the maintained branch set.
+- Rollback is limited to GitHub Actions/docs/scripts when publish behavior is untouched.
+
+## Manual commands
+
+```bash
+HOME=/home/openclaw XDG_CONFIG_HOME= gh run list --repo woosungchoi/fpm-alpine --branch 8.5 --limit 10
+HOME=/home/openclaw XDG_CONFIG_HOME= gh workflow run verify-published-manifest.yml --repo woosungchoi/fpm-alpine --ref 8.5 -f image_ref=woosungchoi/fpm-alpine:8.5
+HOME=/home/openclaw XDG_CONFIG_HOME= gh workflow run dependency-freshness.yml --repo woosungchoi/fpm-alpine --ref 8.5
+HOME=/home/openclaw XDG_CONFIG_HOME= gh workflow run branch-drift.yml --repo woosungchoi/fpm-alpine --ref 8.5
+```
+
+## Branch protection rollback
+
+If a required check name is changed accidentally:
+
+1. Restore the previous required status check name in GitHub branch protection: `docker-smoke`.
+2. Re-run the PR workflow.
+3. Confirm the check appears on the PR as a required check.
+4. Only then merge or re-enable stricter settings.

--- a/scripts/branch-drift-report.sh
+++ b/scripts/branch-drift-report.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH_DRIFT_BRANCHES="${BRANCH_DRIFT_BRANCHES:-8.0 8.1 8.2 8.3 8.4 8.5}"
+BRANCH_DRIFT_FILES="${BRANCH_DRIFT_FILES:-.github/workflows/smoke-test.yml .github/workflows/verify-published-manifest.yml .github/workflows/dependency-freshness.yml scripts/smoke-test-image.sh scripts/report-manifest.sh scripts/report-freshness.sh Dockerfile BRANCH-AND-TAG-POLICY.md README.md}"
+BRANCH_DRIFT_REPORT_DIR="${BRANCH_DRIFT_REPORT_DIR:-branch-drift-reports}"
+BRANCH_DRIFT_ALLOWLIST="${BRANCH_DRIFT_ALLOWLIST:-docs/branch-drift-allowlist.tsv}"
+BASE_BRANCH="${BRANCH_DRIFT_BASE_BRANCH:-8.5}"
+
+mkdir -p "$BRANCH_DRIFT_REPORT_DIR"
+json_file="$BRANCH_DRIFT_REPORT_DIR/branch-drift.json"
+md_file="$BRANCH_DRIFT_REPORT_DIR/branch-drift.md"
+
+python3 - "$json_file" "$md_file" "$BASE_BRANCH" "$BRANCH_DRIFT_ALLOWLIST" "$BRANCH_DRIFT_BRANCHES" "$BRANCH_DRIFT_FILES" <<'PY'
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+json_file = Path(sys.argv[1])
+md_file = Path(sys.argv[2])
+base_branch = sys.argv[3]
+allowlist_path = Path(sys.argv[4])
+branches = sys.argv[5].split()
+files = sys.argv[6].split()
+
+allowlist = set()
+if allowlist_path.exists():
+    for line in allowlist_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("path\t"):
+            continue
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            allowlist.add((parts[0], parts[1]))
+
+def git_show(branch, path):
+    try:
+        return subprocess.check_output(["git", "show", f"origin/{branch}:{path}"], stderr=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        try:
+            return subprocess.check_output(["git", "show", f"{branch}:{path}"], stderr=subprocess.DEVNULL)
+        except subprocess.CalledProcessError:
+            return None
+
+def digest(content):
+    if content is None:
+        return None
+    return hashlib.sha256(content).hexdigest()[:16]
+
+def extract_baseline(content):
+    if content is None:
+        return None, None
+    text = content.decode("utf-8", errors="replace")
+    from_line = None
+    imagick = None
+    for line in text.splitlines():
+        if line.startswith("FROM ") and from_line is None:
+            from_line = line.split()[1]
+        if line.startswith("ARG IMAGICK_VERSION=") and imagick is None:
+            imagick = line.split("=", 1)[1].strip()
+    return from_line, imagick
+
+records = []
+for path in files:
+    base_content = git_show(base_branch, path)
+    base_digest = digest(base_content)
+    for branch in branches:
+        content = git_show(branch, path)
+        item_digest = digest(content)
+        status = "ok"
+        if content is None:
+            status = "missing"
+        elif base_digest != item_digest:
+            status = "allowed-drift" if (path, branch) in allowlist else "drift"
+        base_from, base_imagick = extract_baseline(base_content) if path == "Dockerfile" else (None, None)
+        item_from, item_imagick = extract_baseline(content) if path == "Dockerfile" else (None, None)
+        records.append({
+            "path": path,
+            "branch": branch,
+            "baseBranch": base_branch,
+            "status": status,
+            "digest": item_digest,
+            "baseDigest": base_digest,
+            "baseImage": item_from,
+            "imagickVersion": item_imagick,
+            "baseBranchImage": base_from,
+            "baseBranchImagickVersion": base_imagick,
+            "allowlisted": (path, branch) in allowlist,
+        })
+
+summary = {
+    "mode": "report-only",
+    "baseBranch": base_branch,
+    "branches": branches,
+    "files": files,
+    "records": records,
+    "counts": {},
+}
+for record in records:
+    summary["counts"][record["status"]] = summary["counts"].get(record["status"], 0) + 1
+json_file.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+lines = [
+    "# fpm-alpine branch drift report",
+    "",
+    "This workflow is report-only. It detects workflow/script/policy drift across maintained branches and does not modify repository files or create PRs.",
+    "",
+    f"- Base branch: `{base_branch}`",
+    "- Maintained branches: " + ", ".join(f"`{b}`" for b in branches),
+    "- Allowlist: `" + str(allowlist_path) + "`",
+    "",
+    "## Summary",
+    "",
+]
+for key in sorted(summary["counts"]):
+    lines.append(f"- `{key}`: {summary['counts'][key]}")
+lines.extend(["", "## Drift details", ""])
+for record in records:
+    if record["status"] == "ok":
+        continue
+    suffix = ""
+    if record["path"] == "Dockerfile":
+        suffix = f" — base image `{record.get('baseImage')}`, imagick `{record.get('imagickVersion')}`"
+    lines.append(f"- `{record['branch']}` `{record['path']}`: **{record['status']}**{suffix}")
+if all(record["status"] == "ok" for record in records):
+    lines.append("- No drift detected against the selected base branch.")
+lines.extend([
+    "",
+    "## Dockerfile baseline matrix",
+    "",
+])
+for record in records:
+    if record["path"] == "Dockerfile":
+        lines.append(f"- `{record['branch']}`: base `{record.get('baseImage') or 'missing'}`, imagick `{record.get('imagickVersion') or 'missing'}`, status `{record['status']}`")
+lines.extend([
+    "",
+    "## Operating note",
+    "",
+    "Unexpected `drift` means a maintained branch may be missing a workflow/script/policy update. `allowed-drift` should have a short reason in the allowlist. Review manually before syncing branches.",
+    "",
+])
+md_file.write_text("\n".join(lines))
+print(md_file.read_text())
+PY
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$md_file" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/check-manifest.sh
+++ b/scripts/check-manifest.sh
@@ -3,50 +3,11 @@ set -euo pipefail
 
 IMAGE_REF="${1:-}"
 shift || true
-EXPECTED_PLATFORMS=("$@")
 if [ -z "$IMAGE_REF" ]; then
   echo "usage: $0 <registry-image-ref> [expected-platform ...]" >&2
   echo "example: $0 woosungchoi/fpm-alpine:8.5 linux/amd64 linux/arm64" >&2
   exit 64
 fi
 
-if [ ${#EXPECTED_PLATFORMS[@]} -eq 0 ]; then
-  EXPECTED_PLATFORMS=(linux/amd64 linux/arm64)
-fi
-
-raw_json="$(docker buildx imagetools inspect --raw "$IMAGE_REF")"
-printf '%s\n' "$raw_json"
-
-MANIFEST_RAW_JSON="$raw_json" python3 - "$IMAGE_REF" "${EXPECTED_PLATFORMS[@]}" <<'PY'
-import json
-import os
-import sys
-
-image_ref = sys.argv[1]
-expected = sys.argv[2:]
-raw = os.environ.get('MANIFEST_RAW_JSON', '')
-if not raw.strip():
-    print(f"empty manifest output for {image_ref}", file=sys.stderr)
-    sys.exit(1)
-
-data = json.loads(raw)
-platforms = set()
-for manifest in data.get("manifests", []):
-    platform = manifest.get("platform") or {}
-    os_name = platform.get("os")
-    arch = platform.get("architecture")
-    variant = platform.get("variant")
-    if os_name and arch:
-        value = f"{os_name}/{arch}"
-        platforms.add(value)
-        if variant:
-            platforms.add(f"{value}/{variant}")
-
-missing = [item for item in expected if item not in platforms]
-if missing:
-    print(f"manifest platforms present: {sorted(platforms)}", file=sys.stderr)
-    print(f"missing manifest platform(s) for {image_ref}: {', '.join(missing)}", file=sys.stderr)
-    sys.exit(1)
-
-print(f"manifest check passed for {image_ref}: {', '.join(expected)}")
-PY
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$script_dir/report-manifest.sh" "$IMAGE_REF" "$@"

--- a/scripts/report-freshness.sh
+++ b/scripts/report-freshness.sh
@@ -26,15 +26,61 @@ text = dockerfile.read_text()
 base_match = re.search(r"^FROM\s+([^\s]+)", text, re.MULTILINE)
 imagick_match = re.search(r"^ARG\s+IMAGICK_VERSION=([^\s]+)", text, re.MULTILINE)
 uses_gnu_libiconv = "gnu-libiconv" in text and "LD_PRELOAD=/usr/lib/preloadable_libiconv.so" in text
+apk_packages = []
+lines = text.splitlines()
+idx = 0
+while idx < len(lines):
+    line = lines[idx]
+    if "apk add" not in line:
+        idx += 1
+        continue
+    block = [line]
+    while ";" not in lines[idx] and idx + 1 < len(lines):
+        nxt = lines[idx + 1]
+        if re.match(r"^(RUN|ENV|ARG|FROM|COPY|ADD|CMD|ENTRYPOINT)\b", nxt):
+            break
+        idx += 1
+        block.append(lines[idx])
+    uncommented = "\n".join(part.split("#", 1)[0] for part in block)
+    body = uncommented
+    for raw in re.split(r"\s+", body.replace("\\", " ")):
+        token = raw.strip().strip(";,#\"'")
+        if not token or token.startswith("-") or token.startswith("$"):
+            continue
+        if token in {"RUN", "apk", "add", "set", "eux", "ex", "in", "theory", "is", "but", "priority"}:
+            continue
+        if token.startswith("https://") or token.startswith("http://"):
+            continue
+        if token.startswith("PHP") or token in {"dl-cdn.alpinelinux.org", "alpine", "edge", "community"}:
+            continue
+        if "/" in token or "=" in token:
+            continue
+        apk_packages.append(token)
+    idx += 1
+pecl_installs = []
+for line in text.splitlines():
+    if "pecl install" in line:
+        cleaned = line.replace(";", " ").replace("\\", " ")
+        parts = cleaned.split()
+        if "install" in parts:
+            idx = parts.index("install")
+            pecl_installs.extend(part for part in parts[idx + 1:] if not part.startswith("-"))
 
 data = {
     "dockerfile": str(dockerfile),
     "baseImage": base_match.group(1) if base_match else None,
     "pinnedImagickVersion": imagick_match.group(1) if imagick_match else None,
     "usesGnuLibiconvWorkaround": uses_gnu_libiconv,
+    "apkPackageSignals": sorted(set(apk_packages)),
+    "peclInstallSignals": sorted(set(pecl_installs)),
     "pecl": [],
     "images": [],
+    "warnings": [],
 }
+if not data["pinnedImagickVersion"]:
+    data["warnings"].append("IMAGICK_VERSION baseline missing")
+elif not re.fullmatch(r"\d+\.\d+\.\d+(?:[A-Za-z0-9._-]*)?", data["pinnedImagickVersion"]):
+    data["warnings"].append("IMAGICK_VERSION baseline is not a recognizable semver-like value")
 out.write_text(json.dumps(data, indent=2) + "\n")
 PY
 
@@ -91,9 +137,7 @@ for package in $PECL_PACKAGES; do
 import json, sys
 path, package, latest, status = sys.argv[1:]
 data = json.load(open(path))
-pinned = None
-if package == "imagick":
-    pinned = data.get("pinnedImagickVersion")
+pinned = data.get("pinnedImagickVersion") if package == "imagick" else None
 data.setdefault("pecl", []).append({
     "package": package,
     "pinned": pinned,
@@ -117,7 +161,7 @@ out = Path(sys.argv[2])
 lines = []
 lines.append("# fpm-alpine dependency freshness report")
 lines.append("")
-lines.append("This report is observational only. It does not publish images or change dependency pins.")
+lines.append("This report is observational only. It does not publish images, open PRs, or change dependency pins.")
 lines.append("")
 lines.append("## Dockerfile pins")
 lines.append("")
@@ -126,11 +170,20 @@ lines.append(f"- Base image: `{data.get('baseImage') or 'unknown'}`")
 lines.append(f"- Pinned Imagick: `{data.get('pinnedImagickVersion') or 'unknown'}`")
 lines.append(f"- gnu-libiconv workaround present: `{str(data.get('usesGnuLibiconvWorkaround')).lower()}`")
 lines.append("")
+lines.append("## Installed package signals")
+lines.append("")
+apk = data.get("apkPackageSignals") or []
+pecl = data.get("peclInstallSignals") or []
+lines.append("- APK/runtime signals: " + (", ".join(f"`{item}`" for item in apk) if apk else "`none detected`"))
+lines.append("- PECL install signals: " + (", ".join(f"`{item}`" for item in pecl) if pecl else "`none detected`"))
+lines.append("")
 lines.append("## Image digests")
 lines.append("")
 for item in data.get("images", []):
     digest = item.get("digest") or "unavailable"
     lines.append(f"- `{item['ref']}`: `{digest}` ({item['status']})")
+if not data.get("images"):
+    lines.append("- No image digest checks requested in this run.")
 lines.append("")
 lines.append("## PECL latest releases")
 lines.append("")
@@ -139,12 +192,27 @@ for item in data.get("pecl", []):
     latest = item.get("latest") or "unavailable"
     marker = "update available" if item.get("updateAvailable") else "ok/report-only"
     lines.append(f"- `{item['package']}`: pinned `{pinned}`, latest `{latest}` ({item['status']}, {marker})")
+if not data.get("pecl"):
+    lines.append("- No PECL latest checks requested in this run.")
 lines.append("")
+lines.append("## Manual follow-up guide")
+lines.append("")
+lines.append("- Treat `inspect_failed` as an observation first: check Docker Hub/registry availability before changing source.")
+lines.append("- Treat PECL latest changes as manual review prompts, not automatic Dockerfile updates.")
+lines.append("- Keep `imagick-3.8.1` unless a branch-specific smoke test proves a newer baseline is safe.")
+lines.append("- Reassess `gnu-libiconv` only with branch-by-branch image smoke coverage.")
+if data.get("warnings"):
+    lines.append("")
+    lines.append("## Warnings")
+    lines.append("")
+    for warning in data["warnings"]:
+        lines.append(f"- ⚠️ {warning}")
 if data.get("usesGnuLibiconvWorkaround"):
+    lines.append("")
     lines.append("## Manual review note")
     lines.append("")
     lines.append("The Dockerfile still uses the Alpine edge `gnu-libiconv` workaround with `LD_PRELOAD`. Reassess periodically against the current PHP/Alpine base image before removing it.")
-    lines.append("")
+lines.append("")
 out.write_text("\n".join(lines))
 PY
 

--- a/scripts/report-manifest.sh
+++ b/scripts/report-manifest.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 IMAGE_REF="${1:-}"
 shift || true
 EXPECTED_PLATFORMS=("$@")
+MANIFEST_RETRY_ATTEMPTS="${MANIFEST_RETRY_ATTEMPTS:-5}"
+MANIFEST_RETRY_DELAY_SECONDS="${MANIFEST_RETRY_DELAY_SECONDS:-20}"
 
 if [ -z "$IMAGE_REF" ]; then
   echo "usage: $0 <registry-image-ref> [expected-platform ...]" >&2
@@ -20,15 +22,47 @@ mkdir -p "$report_dir"
 raw_file="$report_dir/${safe_name}.raw.json"
 json_file="$report_dir/${safe_name}.summary.json"
 md_file="$report_dir/${safe_name}.md"
+inspect_log="$report_dir/${safe_name}.inspect.log"
 
-inspect_text="$(docker buildx imagetools inspect "$IMAGE_REF")"
+inspect_text=""
+raw_status=""
+: > "$inspect_log"
+for attempt in $(seq 1 "$MANIFEST_RETRY_ATTEMPTS"); do
+  echo "manifest inspect attempt ${attempt}/${MANIFEST_RETRY_ATTEMPTS}: ${IMAGE_REF}" | tee -a "$inspect_log"
+  if inspect_text="$(docker buildx imagetools inspect "$IMAGE_REF" 2>&1)"; then
+    if docker buildx imagetools inspect --raw "$IMAGE_REF" > "$raw_file" 2>>"$inspect_log"; then
+      raw_status="ok"
+      break
+    fi
+  else
+    printf '%s\n' "$inspect_text" >> "$inspect_log"
+  fi
+
+  if [ "$attempt" -lt "$MANIFEST_RETRY_ATTEMPTS" ]; then
+    echo "manifest not available yet; retrying after ${MANIFEST_RETRY_DELAY_SECONDS}s" | tee -a "$inspect_log"
+    sleep "$MANIFEST_RETRY_DELAY_SECONDS"
+  fi
+done
+
+if [ "$raw_status" != "ok" ]; then
+  cat > "$md_file" <<EOF
+## \`${IMAGE_REF}\`
+
+- Status: ❌ manifest inspect failed after ${MANIFEST_RETRY_ATTEMPTS} attempt(s)
+- Expected platforms: $(printf '`%s` ' "${EXPECTED_PLATFORMS[@]}")
+
+This can be caused by Docker Hub propagation lag, registry/network failure, or a genuinely missing tag. Re-run the manual workflow after Docker Hub has finished publishing before changing publish hooks.
+EOF
+  cat "$md_file" >&2
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then cat "$md_file" >> "$GITHUB_STEP_SUMMARY"; fi
+  exit 1
+fi
+
 digest="$(awk '/^Digest:/ { print $2; exit }' <<< "$inspect_text")"
 if [ -z "$digest" ]; then
   echo "failed to resolve digest for $IMAGE_REF" >&2
   exit 1
 fi
-
-docker buildx imagetools inspect --raw "$IMAGE_REF" > "$raw_file"
 
 parser_file="$(mktemp)"
 trap 'rm -f "$parser_file"' EXIT
@@ -66,9 +100,7 @@ for item in manifest.get("manifests", []):
 
     if os_name and arch:
         base_value = f"{os_name}/{arch}"
-        value = base_value
-        if variant:
-            value = f"{value}/{variant}"
+        value = f"{base_value}/{variant}" if variant else base_value
         platforms.append({"platform": value, "digest": item_digest, "mediaType": media_type})
 
 found = {item["platform"] for item in platforms}
@@ -93,6 +125,7 @@ lines = [
     f"- Digest: `{digest}`",
     f"- Expected platforms: {', '.join(f'`{item}`' for item in expected)}",
     f"- Status: {'✅ passed' if not missing else '❌ missing ' + ', '.join(missing)}",
+    "- Publish path: Docker Hub hooks remain the source of published images; this workflow is observation only.",
     "",
     "### Platforms",
     "",
@@ -105,7 +138,13 @@ if attestations:
         ref = item.get("referenceDigest") or "unknown reference"
         rtype = item.get("referenceType") or "unknown type"
         lines.append(f"- `{rtype}` for `{ref}` — `{item.get('digest')}`")
-lines.append("")
+lines.extend([
+    "",
+    "### Triage note",
+    "",
+    "If this failed immediately after a push, first suspect Docker Hub propagation lag or registry/network issues. Re-run the manual manifest workflow before changing build or publish logic.",
+    "",
+])
 md_file.write_text("\n".join(lines))
 
 if missing:

--- a/scripts/smoke-test-image.sh
+++ b/scripts/smoke-test-image.sh
@@ -2,10 +2,20 @@
 set -euo pipefail
 
 IMAGE_NAME="${1:-}"
+SMOKE_REPORT_DIR="${SMOKE_REPORT_DIR:-smoke-reports}"
+SMOKE_REPORT_MD="${SMOKE_REPORT_MD:-${SMOKE_REPORT_DIR}/smoke-test.md}"
+
 if [ -z "$IMAGE_NAME" ]; then
   echo "usage: $0 <image-name>" >&2
   exit 64
 fi
+
+mkdir -p "$(dirname "$SMOKE_REPORT_MD")"
+: > "$SMOKE_REPORT_MD"
+
+append_summary() {
+  printf '%s\n' "$*" >> "$SMOKE_REPORT_MD"
+}
 
 container_id=""
 cleanup() {
@@ -19,27 +29,67 @@ run_in_container() {
   docker exec "$container_id" sh -lc "$1"
 }
 
+run_check() {
+  local name="$1"
+  local command="$2"
+  printf '\n== %s ==\n' "$name"
+  append_summary "- ⏳ ${name}"
+  if run_in_container "$command"; then
+    # Replace the pending marker with a passing marker while keeping order stable.
+    python3 - "$SMOKE_REPORT_MD" "$name" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+name = sys.argv[2]
+text = path.read_text()
+text = text.replace(f"- ⏳ {name}\n", f"- ✅ {name}\n", 1)
+path.write_text(text)
+PY
+  else
+    python3 - "$SMOKE_REPORT_MD" "$name" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+name = sys.argv[2]
+text = path.read_text()
+text = text.replace(f"- ⏳ {name}\n", f"- ❌ {name}\n", 1)
+path.write_text(text)
+PY
+    echo "smoke check failed: ${name}" >&2
+    echo "php-fpm log follows, if available:" >&2
+    docker exec "$container_id" sh -lc 'cat /tmp/php-fpm.log 2>/dev/null || true' >&2 || true
+    exit 1
+  fi
+}
+
+cat > "$SMOKE_REPORT_MD" <<EOF
+# fpm-alpine smoke test report
+
+- Image: \`${IMAGE_NAME}\`
+- Mode: container runtime validation, not publish
+
+## Checks
+
+EOF
+
 container_id="$(docker run -d --rm --entrypoint sh "$IMAGE_NAME" -c 'php-fpm -F >/tmp/php-fpm.log 2>&1 & while :; do sleep 3600; done')"
 
-printf '\n== php -v ==\n'
-run_in_container 'php -v'
+run_check "php -v" 'php -v'
+run_check "php -m" 'php -m | sort'
+run_check "php-fpm -t" 'php-fpm -t'
+run_check "extension: imagick" "php -r 'if (!extension_loaded(\"imagick\")) { fwrite(STDERR, \"imagick extension missing\\n\"); exit(1); } echo \"imagick=loaded\\n\";'"
+run_check "extension: redis" "php -r 'if (!extension_loaded(\"redis\")) { fwrite(STDERR, \"redis extension missing\\n\"); exit(1); } echo \"redis=loaded\\n\";'"
+run_check "extension: apcu" "php -r 'if (!extension_loaded(\"apcu\")) { fwrite(STDERR, \"apcu extension missing\\n\"); exit(1); } echo \"apcu=loaded\\n\";'"
+run_check "ffmpeg" 'command -v ffmpeg && ffmpeg -version | head -n 1'
+run_check "iconv runtime" "php -r 'echo iconv(\"UTF-8\", \"UTF-8\", \"iconv-ok\") . PHP_EOL;'"
+run_check "Imagick class runtime" "php -r '\$i = new Imagick(); echo \"imagick-class-ok\\n\";'"
 
-printf '\n== php -m ==\n'
-run_in_container 'php -m | sort'
+append_summary ""
+append_summary "Smoke test passed for \`${IMAGE_NAME}\`."
 
-printf '\n== php-fpm -t ==\n'
-run_in_container 'php-fpm -t'
-
-printf '\n== extension load checks ==\n'
-run_in_container "php -r 'foreach ([\"imagick\",\"redis\",\"apcu\"] as \$ext) { if (!extension_loaded(\$ext)) { fwrite(STDERR, \$ext . \" extension missing\\n\"); exit(1); } echo \$ext . \"=loaded\\n\"; }'"
-
-printf '\n== ffmpeg ==\n'
-run_in_container 'command -v ffmpeg && ffmpeg -version | head -n 1'
-
-printf '\n== iconv ==\n'
-run_in_container "php -r 'echo iconv(\"UTF-8\", \"UTF-8\", \"iconv-ok\") . PHP_EOL;'"
-
-printf '\n== imagick runtime ==\n'
-run_in_container "php -r '\$i = new Imagick(); echo \"imagick-class-ok\\n\";'"
+cat "$SMOKE_REPORT_MD"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$SMOKE_REPORT_MD" >> "$GITHUB_STEP_SUMMARY"
+fi
 
 printf '\nSmoke test passed for %s\n' "$IMAGE_NAME"

--- a/tests/test_policy_scripts.sh
+++ b/tests/test_policy_scripts.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file() {
+  local path="$1"
+  [ -f "$path" ] || fail "expected file $path to exist"
+}
+
+assert_executable() {
+  local path="$1"
+  [ -x "$path" ] || fail "expected $path to be executable"
+}
+
+assert_contains() {
+  local path="$1"
+  local needle="$2"
+  grep -Fq "$needle" "$path" || fail "expected $path to contain: $needle"
+}
+
+assert_file docs/ci-operations.md
+assert_contains docs/ci-operations.md "Required status check"
+assert_contains docs/ci-operations.md "Docker Hub hooks remain the publish path"
+assert_contains docs/ci-operations.md "Rollback"
+
+assert_file docs/branch-drift-allowlist.tsv
+assert_contains docs/branch-drift-allowlist.tsv "path"
+
+assert_file scripts/branch-drift-report.sh
+assert_executable scripts/branch-drift-report.sh
+
+branch_report_dir="$(mktemp -d)"
+trap 'rm -rf "$branch_report_dir"' EXIT
+BRANCH_DRIFT_BRANCHES="8.5" BRANCH_DRIFT_REPORT_DIR="$branch_report_dir" ./scripts/branch-drift-report.sh
+assert_file "$branch_report_dir/branch-drift.md"
+assert_file "$branch_report_dir/branch-drift.json"
+assert_contains "$branch_report_dir/branch-drift.md" "# fpm-alpine branch drift report"
+assert_contains "$branch_report_dir/branch-drift.md" "report-only"
+assert_contains "$branch_report_dir/branch-drift.md" "8.5"
+
+fixture_dir="$(mktemp -d)"
+cat > "$fixture_dir/Dockerfile" <<'DOCKERFILE'
+ARG IMAGICK_VERSION=3.8.1
+FROM php:8.5-fpm-alpine
+RUN apk add --no-cache bash ffmpeg imagemagick ghostscript
+RUN pecl install redis apcu
+RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted gnu-libiconv
+ENV LD_PRELOAD=/usr/lib/preloadable_libiconv.so
+DOCKERFILE
+REPORT_DIR="$fixture_dir/reports" DOCKERFILE_PATH="$fixture_dir/Dockerfile" PHP_TAGS="" PECL_PACKAGES="" ./scripts/report-freshness.sh
+assert_contains "$fixture_dir/reports/dependency-freshness.md" "Installed package signals"
+assert_contains "$fixture_dir/reports/dependency-freshness.md" "Manual follow-up guide"
+assert_contains "$fixture_dir/reports/dependency-freshness.md" 'Pinned Imagick: `3.8.1`'
+
+assert_contains scripts/smoke-test-image.sh "run_check \"extension: imagick\""
+assert_contains scripts/smoke-test-image.sh "GITHUB_STEP_SUMMARY"
+assert_contains scripts/report-manifest.sh "MANIFEST_RETRY_ATTEMPTS"
+assert_contains scripts/report-manifest.sh "Docker Hub propagation lag"
+
+bash -n scripts/smoke-test-image.sh
+bash -n scripts/report-manifest.sh
+bash -n scripts/report-freshness.sh
+bash -n scripts/branch-drift-report.sh
+
+echo "policy script tests passed"


### PR DESCRIPTION
## Summary
- Add report-only `branch-drift` workflow and branch drift script/allowlist.
- Add CI operations runbook covering required checks, triage, and rollback.
- Improve smoke-test reporting, manifest retry/triage output, and dependency freshness summaries.
- Add policy script tests for authless/report-only guardrails.

## Test Plan
- [x] `./tests/test_policy_scripts.sh`
- [x] `bash -n scripts/*.sh tests/*.sh`
- [x] `git diff --check`
- [x] workflow YAML parse sanity
- [x] `docker build -t fpm-alpine:hermes-ci .`
- [x] `SMOKE_REPORT_DIR=/tmp/fpm-smoke ./scripts/smoke-test-image.sh fpm-alpine:hermes-ci`
- [x] `MANIFEST_RETRY_ATTEMPTS=1 ./scripts/report-manifest.sh woosungchoi/fpm-alpine:8.5`
- [x] nonexistent tag RED check fails clearly
- [x] branch protection required check confirmed as `docker-smoke` on `8.0`-`8.5`

## Operational notes
- Docker Hub hooks remain the publish path.
- `verify-published-manifest`, `dependency-freshness`, and `branch-drift` remain report-only/non-required workflows.
