### PR TITLE
ci: add safe branch drift sync PR automation

### DIFF
--- a/.github/workflows/branch-sync-pr.yml
+++ b/.github/workflows/branch-sync-pr.yml
@@ -1,0 +1,79 @@
+name: branch-sync-pr
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "Optional single target branch"
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+  schedule:
+    - cron: '37 5 * * 1'
+
+concurrency:
+  group: branch-sync-pr-${{ github.ref }}-${{ inputs.target_branch || 'all' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+jobs:
+  create-safe-sync-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BRANCH_SYNC_BASE: "8.5"
+      BRANCH_SYNC_TARGETS: ${{ github.event_name == 'workflow_dispatch' && inputs.target_branch != 'all' && inputs.target_branch || '8.0 8.1 8.2 8.3 8.4' }}
+      BRANCH_SYNC_OUTPUT_DIR: branch-sync-plans
+      BRANCH_SYNC_PR_LABELS: "maintenance,branch-sync,safe-sync"
+      DRY_RUN: "0"
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Validate target branch input
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch || 'all' }}
+        run: |
+          set -euo pipefail
+          case "$TARGET_BRANCH" in
+            all|8.0|8.1|8.2|8.3|8.4) ;;
+            *) echo "Unsupported target_branch: $TARGET_BRANCH" >&2; exit 64 ;;
+          esac
+
+      - name: Checkout maintained branches
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch maintained branch refs
+        run: |
+          git fetch origin 8.0 8.1 8.2 8.3 8.4 8.5 --prune
+
+      - name: Plan safe branch sync
+        run: ./scripts/plan-branch-sync.sh
+
+      - name: Create or update branch sync PRs
+        run: ./scripts/create-branch-sync-prs.sh
+
+      - name: Upload branch sync plans
+        if: always()
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: branch-sync-plans
+          path: branch-sync-plans/

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ This repository is maintained through version branches and lightweight verificat
 - `verify-published-manifest` runs on a schedule and verifies the published Docker Hub tags for maintained branches.
 - `dependency-freshness` produces report-only dependency/source freshness observations for maintainers.
 - `branch-drift` produces report-only workflow/script/policy drift reports across maintained branches.
+- `branch-sync-pr` can create safe-file sync PRs from `8.5` to maintained branches for workflow/script/docs/test guardrails only.
 - Maintained branches use the documented Imagick baseline in [BRANCH-AND-TAG-POLICY.md](./BRANCH-AND-TAG-POLICY.md).
 - Security reporting and supported-version policy are documented in [SECURITY.md](./SECURITY.md).
 

--- a/docs/branch-sync-auto-merge-policy.md
+++ b/docs/branch-sync-auto-merge-policy.md
@@ -1,0 +1,42 @@
+# Branch sync auto-merge policy draft
+
+This document intentionally describes a future policy only. The current `branch-sync-pr` workflow creates PRs and does **not** auto-merge them.
+
+## Current policy
+
+- `branch-sync-pr` may create PRs for safe workflow/script/docs/test guardrail syncs.
+- Generated PRs require human review.
+- Required check remains `docker-smoke` on every maintained branch.
+- Docker Hub hooks remain the publish path.
+
+## Future auto-merge allow conditions
+
+A future workflow may consider auto-merge only when all conditions are true:
+
+- PR author is `github-actions[bot]`.
+- PR has `safe-sync` and `branch-sync` labels.
+- Changed files are all listed in `docs/branch-sync-safe-files.txt`.
+- No `Dockerfile`, `hooks/*`, publish-sensitive file, branch protection setting, PHP base image, `IMAGICK_VERSION`, `gnu-libiconv`, or `LD_PRELOAD` change is present.
+- `docker-smoke` passes on the target branch PR.
+- Branch protection still requires only the expected required checks.
+- Generated PR body contains synced files, blocked/manual files, and the Docker Hub safety note.
+
+## Auto-merge deny conditions
+
+Never auto-merge when any of these are true:
+
+- `Dockerfile` changed.
+- `hooks/*` changed.
+- Docker Hub publish path changed.
+- `ARG IMAGICK_VERSION` changed.
+- `gnu-libiconv` or `LD_PRELOAD` changed.
+- PHP base image line changed.
+- Required status checks changed.
+- `docker-smoke` is missing, pending, cancelled, skipped, or failed.
+- The generated plan has any blocked/manual files that require implementation in the same PR.
+
+## Suggested future workflow name
+
+- `.github/workflows/branch-sync-auto-merge.yml`
+
+Keep this as a separate PR from PR generation so failures in merge policy cannot block safe PR creation.

--- a/docs/branch-sync-safe-files.txt
+++ b/docs/branch-sync-safe-files.txt
@@ -1,0 +1,18 @@
+# Safe files that branch-sync automation may copy from 8.5 to maintained version branches.
+# Dockerfile, hooks/*, image build contexts, and branch-protection settings are intentionally excluded.
+.github/workflows/branch-drift.yml
+.github/workflows/dependency-freshness.yml
+.github/workflows/verify-published-manifest.yml
+.github/workflows/smoke-test.yml
+.github/workflows/branch-sync-pr.yml
+scripts/branch-drift-report.sh
+scripts/plan-branch-sync.sh
+scripts/create-branch-sync-prs.sh
+scripts/report-freshness.sh
+scripts/report-manifest.sh
+scripts/check-manifest.sh
+scripts/smoke-test-image.sh
+docs/ci-operations.md
+docs/branch-drift-allowlist.tsv
+docs/branch-sync-safe-files.txt
+tests/test_policy_scripts.sh

--- a/docs/ci-operations.md
+++ b/docs/ci-operations.md
@@ -29,6 +29,10 @@ Non-required / report-only workflows:
 - `branch-drift`
   - Report-only maintained-branch drift detection.
   - Does not sync branches automatically.
+- `branch-sync-pr`
+  - Creates safe-file sync PRs from `8.5` to maintained version branches.
+  - Only copies allowlisted workflow/script/docs/test guardrails.
+  - Never copies `Dockerfile`, Docker Hub hooks, or publish-sensitive files.
 
 ## Workflow responsibilities
 
@@ -115,12 +119,37 @@ Triage:
 1. Review `branch-drift-reports/branch-drift.md`.
 2. Ignore `allowed-drift` only if the allowlist reason still matches current policy.
 3. For unexpected `drift`, manually inspect the file difference before syncing.
-4. Open an explicit PR for any branch sync; do not auto-merge branch-wide drift fixes.
+4. Use `branch-sync-pr` only for allowlisted safe workflow/script/docs/test guardrails.
+5. Open an explicit PR for any non-safe branch sync; do not auto-merge branch-wide drift fixes.
 
 Rollback:
 
 - Disable or revert the `branch-drift` workflow if it is noisy.
 - Keep the allowlist narrow and reasoned.
+
+### `branch-sync-pr`
+
+Purpose: Create safe-file sync PRs from `8.5` to maintained branches `8.0` through `8.4` when report-only branch drift identifies missing guardrails.
+
+Automation boundary:
+
+- Allowed: files listed in `docs/branch-sync-safe-files.txt`.
+- Blocked/manual: `Dockerfile`, Docker Hub hooks, publish-sensitive files, PHP base image lines, `IMAGICK_VERSION`, `gnu-libiconv`, and branch protection settings.
+- Merge policy: generated PRs require human review; this workflow does not auto-merge.
+
+Triage:
+
+1. Run `branch-sync-pr` manually with a single `target_branch` first when testing changes.
+2. Review the generated PR body for synced files and blocked/manual files.
+3. Confirm the PR only touches workflow/script/docs/test guardrails.
+4. Wait for target-branch `docker-smoke` to pass.
+5. Close the PR if it includes an unexpected safe-file copy or if blocked/manual drift needs a separate human-authored PR.
+
+Rollback:
+
+- Close generated sync PRs without merging.
+- Delete `sync/branch-drift-*` branches if the generated diff is noisy.
+- Revert `.github/workflows/branch-sync-pr.yml` and the two branch-sync scripts if generation itself is faulty.
 
 ## Merge checklist
 

--- a/scripts/create-branch-sync-prs.sh
+++ b/scripts/create-branch-sync-prs.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_BRANCH="${BRANCH_SYNC_BASE:-8.5}"
+TARGETS="${BRANCH_SYNC_TARGETS:-8.0 8.1 8.2 8.3 8.4}"
+OUTPUT_DIR="${BRANCH_SYNC_OUTPUT_DIR:-branch-sync-plans}"
+DRY_RUN="${DRY_RUN:-${BRANCH_SYNC_DRY_RUN:-1}}"
+LABELS="${BRANCH_SYNC_PR_LABELS:-maintenance,branch-sync,safe-sync}"
+LABELS_DISPLAY="$(printf '%s' "$LABELS" | sed 's/,/, /g')"
+BRANCH_PREFIX="${BRANCH_SYNC_BRANCH_PREFIX:-sync/branch-drift}"
+REPO="${GITHUB_REPOSITORY:-woosungchoi/fpm-alpine}"
+
+usage() {
+  cat <<'EOF'
+usage: scripts/create-branch-sync-prs.sh
+
+Environment:
+  DRY_RUN=1                         # default; set 0 to push/create PRs
+  BRANCH_SYNC_BASE=8.5
+  BRANCH_SYNC_TARGETS="8.0 8.1 8.2 8.3 8.4"
+  BRANCH_SYNC_OUTPUT_DIR=branch-sync-plans
+  BRANCH_SYNC_PR_LABELS="maintenance,branch-sync,safe-sync"
+
+Creates or summarizes safe branch-drift sync PRs. Dockerfile/hooks/publish files
+are never copied by this script; it only uses filesToSync from plan JSON.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+mkdir -p "$OUTPUT_DIR"
+if [ ! -f "$OUTPUT_DIR/summary.md" ]; then
+  BRANCH_SYNC_BASE="$BASE_BRANCH" BRANCH_SYNC_TARGETS="$TARGETS" BRANCH_SYNC_OUTPUT_DIR="$OUTPUT_DIR" ./scripts/plan-branch-sync.sh >/dev/null
+fi
+
+prs_md="$OUTPUT_DIR/prs.md"
+cat > "$prs_md" <<EOF
+# fpm-alpine branch sync PR plan
+
+- Base branch: $BASE_BRANCH
+- Mode: safe-files-only
+- Dry run: $DRY_RUN
+- Labels: $LABELS_DISPLAY
+- Safety: Docker Hub hooks are unchanged. Dockerfile and publish-sensitive files are not synced automatically.
+
+EOF
+
+create_labels() {
+  [ "$DRY_RUN" = "0" ] || return 0
+  IFS=',' read -r -a label_array <<< "$LABELS"
+  for label in "${label_array[@]}"; do
+    label="${label// /}"
+    [ -n "$label" ] || continue
+    gh label create "$label" --repo "$REPO" --color "ededed" --description "branch sync automation" >/dev/null 2>&1 || true
+  done
+}
+
+render_pr_body() {
+  local plan_json="$1"
+  python3 - "$plan_json" "$LABELS" <<'PY'
+import json
+import sys
+from pathlib import Path
+plan = json.loads(Path(sys.argv[1]).read_text())
+labels = sys.argv[2].replace(',', ', ')
+print(f"""## Summary
+
+This auto-generated PR syncs safe branch-drift files from `{plan['baseBranch']}` to `{plan['targetBranch']}`.
+
+## Synced files
+""")
+if plan["filesToSync"]:
+    for item in plan["filesToSync"]:
+        print(f"- `{item}`")
+else:
+    print("- No safe drift detected.")
+print("\n## Blocked/manual files\n")
+if plan["blockedFiles"]:
+    for item in plan["blockedFiles"]:
+        print(f"- `{item['path']}` — {item['reason']}")
+else:
+    print("- No blocked drift detected.")
+print(f"""
+## Safety
+
+- Docker Hub hooks are unchanged.
+- Dockerfile is not synced automatically.
+- Required check: `docker-smoke`.
+- Labels: {labels}
+
+## Manual checklist
+
+- [ ] Confirm synced files are limited to workflow/script/docs/test guardrails.
+- [ ] Confirm no Dockerfile, hooks, or publish behavior changed.
+- [ ] Wait for `docker-smoke` to pass on this target branch PR.
+""")
+PY
+}
+
+create_labels
+
+is_blocked_path() {
+  local path="$1"
+  case "$path" in
+    Dockerfile|.dockerignore|hooks|hooks/*|*.secret|*.pem|*.key|branch-sync-plans|branch-sync-plans/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+for target in $TARGETS; do
+  plan_json="$OUTPUT_DIR/$target.json"
+  if [ ! -f "$plan_json" ]; then
+    echo "missing plan $plan_json; run scripts/plan-branch-sync.sh first" >&2
+    exit 1
+  fi
+
+  has_safe_changes="$(python3 -c 'import json,sys; print("1" if json.load(open(sys.argv[1])).get("filesToSync") else "0")' "$plan_json")"
+  branch_name="$BRANCH_PREFIX-$target"
+  body_file="$OUTPUT_DIR/pr-body-$target.md"
+  render_pr_body "$plan_json" > "$body_file"
+
+  {
+    echo "## Target $target"
+    echo ""
+    echo "- Branch: $branch_name"
+    echo '- Required check: `docker-smoke`'
+    echo "- Labels: $LABELS_DISPLAY"
+    echo "- Docker Hub hooks are unchanged."
+    echo ""
+    echo "### Synced files"
+    echo ""
+    python3 - "$plan_json" <<'PY'
+import json, sys
+plan=json.load(open(sys.argv[1]))
+if not plan["filesToSync"]:
+    print("- No safe drift detected; no PR needed.")
+else:
+    for item in plan["filesToSync"]:
+        print(f"- `{item}`")
+PY
+    echo ""
+    echo "### Blocked/manual files"
+    echo ""
+    python3 - "$plan_json" <<'PY'
+import json, sys
+plan=json.load(open(sys.argv[1]))
+if not plan["blockedFiles"]:
+    print("- No blocked drift detected.")
+else:
+    for item in plan["blockedFiles"]:
+        print(f"- `{item['path']}` — {item['reason']}")
+PY
+    echo ""
+  } >> "$prs_md"
+
+  if [ "$has_safe_changes" != "1" ]; then
+    continue
+  fi
+  if [ "$DRY_RUN" != "0" ]; then
+    continue
+  fi
+
+  current_branch="$(git branch --show-current)"
+  cleanup() { git checkout "$current_branch" >/dev/null 2>&1 || true; }
+  trap cleanup RETURN
+
+  git checkout -B "$branch_name" "origin/$target"
+  python3 - "$plan_json" <<'PY' > "$OUTPUT_DIR/files-$target.txt"
+import json, sys
+plan=json.load(open(sys.argv[1]))
+for item in plan["filesToSync"]:
+    print(item)
+PY
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    if is_blocked_path "$path"; then
+      echo "Refusing to sync blocked path from plan: $path" >&2
+      exit 65
+    fi
+    mkdir -p "$(dirname "$path")"
+    git checkout "origin/$BASE_BRANCH" -- "$path"
+  done < "$OUTPUT_DIR/files-$target.txt"
+
+  if git diff --quiet; then
+    echo "No changes after safe sync for $target" >> "$prs_md"
+    git checkout "$current_branch" >/dev/null
+    continue
+  fi
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    git add -- "$path"
+  done < "$OUTPUT_DIR/files-$target.txt"
+  git commit -m "ci: sync safe branch guardrails from $BASE_BRANCH"
+  git push origin "HEAD:$branch_name"
+
+  existing_pr="$(gh pr list --repo "$REPO" --head "$branch_name" --base "$target" --state open --json number --jq '.[0].number // empty')"
+  if [ -n "$existing_pr" ]; then
+    gh pr comment "$existing_pr" --repo "$REPO" --body-file "$body_file" >/dev/null || true
+    echo "Updated existing PR #$existing_pr for $target" >> "$prs_md"
+  else
+    pr_url="$(gh pr create --repo "$REPO" --base "$target" --head "$branch_name" --title "ci: sync safe branch guardrails to $target" --body-file "$body_file")"
+    IFS=',' read -r -a label_array <<< "$LABELS"
+    for label in "${label_array[@]}"; do
+      label="${label// /}"
+      [ -n "$label" ] || continue
+      gh pr edit "$pr_url" --repo "$REPO" --add-label "$label" >/dev/null 2>&1 || true
+    done
+    echo "Created PR: $pr_url" >> "$prs_md"
+  fi
+
+  git checkout "$current_branch" >/dev/null
+  trap - RETURN
+done
+
+cat "$prs_md"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$prs_md" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/plan-branch-sync.sh
+++ b/scripts/plan-branch-sync.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_BRANCH="${BRANCH_SYNC_BASE:-8.5}"
+TARGETS="${BRANCH_SYNC_TARGETS:-8.0 8.1 8.2 8.3 8.4}"
+OUTPUT_DIR="${BRANCH_SYNC_OUTPUT_DIR:-branch-sync-plans}"
+SAFE_FILES_FILE="${BRANCH_SYNC_SAFE_FILES_FILE:-docs/branch-sync-safe-files.txt}"
+BLOCKED_FILES="${BRANCH_SYNC_BLOCKED_FILES:-Dockerfile hooks/build hooks/post_push hooks/push .dockerignore}"
+MODE="safe-files-only"
+
+usage() {
+  cat <<'EOF'
+usage: scripts/plan-branch-sync.sh
+
+Environment:
+  BRANCH_SYNC_BASE=8.5
+  BRANCH_SYNC_TARGETS="8.0 8.1 8.2 8.3 8.4"
+  BRANCH_SYNC_OUTPUT_DIR=branch-sync-plans
+  BRANCH_SYNC_SAFE_FILES_FILE=docs/branch-sync-safe-files.txt
+
+Creates JSON and Markdown plans for safe branch-drift sync PRs. This script is
+report/planning only and never checks out branches, commits, pushes, or creates PRs.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+ref_exists() {
+  local ref="$1"
+  git rev-parse --verify --quiet "$ref" >/dev/null
+}
+
+show_file() {
+  local branch="$1"
+  local path="$2"
+  if ref_exists "origin/${branch}"; then
+    git show "origin/${branch}:${path}" 2>/dev/null || true
+  else
+    git show "${branch}:${path}" 2>/dev/null || true
+  fi
+}
+
+file_exists_in_branch() {
+  local branch="$1"
+  local path="$2"
+  if ref_exists "origin/${branch}"; then
+    git cat-file -e "origin/${branch}:${path}" 2>/dev/null
+  else
+    git cat-file -e "${branch}:${path}" 2>/dev/null
+  fi
+}
+
+file_changed() {
+  local target="$1"
+  local path="$2"
+  local base_tmp target_tmp
+  base_tmp="$(mktemp)"
+  target_tmp="$(mktemp)"
+  show_file "$BASE_BRANCH" "$path" > "$base_tmp"
+  show_file "$target" "$path" > "$target_tmp"
+  if cmp -s "$base_tmp" "$target_tmp"; then
+    rm -f "$base_tmp" "$target_tmp"
+    return 1
+  fi
+  rm -f "$base_tmp" "$target_tmp"
+  return 0
+}
+
+mapfile -t SAFE_FILES < <(grep -Ev '^[[:space:]]*(#|$)' "$SAFE_FILES_FILE")
+
+is_blocked_path() {
+  local path="$1"
+  case "$path" in
+    Dockerfile|.dockerignore|hooks|hooks/*|*.secret|*.pem|*.key)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+summary_md="$OUTPUT_DIR/summary.md"
+cat > "$summary_md" <<EOF
+# fpm-alpine branch sync plan
+
+- Mode: $MODE
+- Base branch: $BASE_BRANCH
+- Targets: $(printf '%s ' $TARGETS)
+- Safe file allowlist: $SAFE_FILES_FILE
+- Note: Docker Hub hooks are unchanged; Dockerfile and publish-sensitive files require manual review.
+
+EOF
+
+for target in $TARGETS; do
+  files_json="$(mktemp)"
+  blocked_json="$(mktemp)"
+  printf '[' > "$files_json"
+  printf '[' > "$blocked_json"
+  first_file=1
+  first_blocked=1
+
+  for path in "${SAFE_FILES[@]}"; do
+    if is_blocked_path "$path"; then
+      continue
+    fi
+    if ! file_exists_in_branch "$BASE_BRANCH" "$path"; then
+      continue
+    fi
+    if file_changed "$target" "$path"; then
+      if [ "$first_file" -eq 0 ]; then printf ',' >> "$files_json"; fi
+      python3 -c 'import json,sys; print(json.dumps(sys.argv[1]), end="")' "$path" >> "$files_json"
+      first_file=0
+    fi
+  done
+
+  for path in $BLOCKED_FILES; do
+    if file_changed "$target" "$path"; then
+      if [ "$first_blocked" -eq 0 ]; then printf ',' >> "$blocked_json"; fi
+      python3 -c 'import json,sys; print(json.dumps({"path": sys.argv[1], "reason": "manual review required"}), end="")' "$path" >> "$blocked_json"
+      first_blocked=0
+    fi
+  done
+
+  printf ']' >> "$files_json"
+  printf ']' >> "$blocked_json"
+
+  python3 - "$OUTPUT_DIR/$target.json" "$BASE_BRANCH" "$target" "$MODE" "$files_json" "$blocked_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+out, base, target, mode, files_path, blocked_path = sys.argv[1:]
+files = json.loads(Path(files_path).read_text())
+blocked = json.loads(Path(blocked_path).read_text())
+plan = {
+    "baseBranch": base,
+    "targetBranch": target,
+    "mode": mode,
+    "filesToSync": files,
+    "blockedFiles": blocked,
+    "hasSafeChanges": bool(files),
+}
+Path(out).write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n")
+PY
+  rm -f "$files_json" "$blocked_json"
+
+  {
+    echo "## Target $target"
+    echo ""
+    echo "### Safe files to sync"
+    echo ""
+    python3 - "$OUTPUT_DIR/$target.json" <<'PY'
+import json, sys
+from pathlib import Path
+plan = json.loads(Path(sys.argv[1]).read_text())
+items = plan["filesToSync"]
+if not items:
+    print("- No safe drift detected.")
+else:
+    for item in items:
+        print(f"- `{item}`")
+PY
+    echo ""
+    echo "### Blocked/manual files"
+    echo ""
+    python3 - "$OUTPUT_DIR/$target.json" <<'PY'
+import json, sys
+from pathlib import Path
+plan = json.loads(Path(sys.argv[1]).read_text())
+items = plan["blockedFiles"]
+if not items:
+    print("- No blocked drift detected.")
+else:
+    for item in items:
+        print(f"- `{item['path']}` — {item['reason']}")
+PY
+    echo ""
+  } >> "$summary_md"
+done
+
+cat "$summary_md"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$summary_md" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/tests/test_policy_scripts.sh
+++ b/tests/test_policy_scripts.sh
@@ -35,15 +35,71 @@ assert_contains docs/branch-drift-allowlist.tsv "path"
 
 assert_file scripts/branch-drift-report.sh
 assert_executable scripts/branch-drift-report.sh
+assert_file scripts/plan-branch-sync.sh
+assert_executable scripts/plan-branch-sync.sh
+assert_file scripts/create-branch-sync-prs.sh
+assert_executable scripts/create-branch-sync-prs.sh
+assert_file .github/workflows/branch-sync-pr.yml
+assert_contains .github/workflows/branch-sync-pr.yml "pull-requests: write"
+assert_contains .github/workflows/branch-sync-pr.yml "actions/checkout@v6.0.2"
+assert_contains .github/workflows/branch-sync-pr.yml "type: choice"
+assert_contains .github/workflows/branch-sync-pr.yml "TARGET_BRANCH:"
 
 branch_report_dir="$(mktemp -d)"
-trap 'rm -rf "$branch_report_dir"' EXIT
+branch_sync_dir="$(mktemp -d)"
+trap 'rm -rf "$branch_report_dir" "$branch_sync_dir"' EXIT
 BRANCH_DRIFT_BRANCHES="8.5" BRANCH_DRIFT_REPORT_DIR="$branch_report_dir" ./scripts/branch-drift-report.sh
 assert_file "$branch_report_dir/branch-drift.md"
 assert_file "$branch_report_dir/branch-drift.json"
 assert_contains "$branch_report_dir/branch-drift.md" "# fpm-alpine branch drift report"
 assert_contains "$branch_report_dir/branch-drift.md" "report-only"
 assert_contains "$branch_report_dir/branch-drift.md" "8.5"
+
+BRANCH_SYNC_TARGETS="8.4" BRANCH_SYNC_OUTPUT_DIR="$branch_sync_dir" BRANCH_SYNC_DRY_RUN=1 ./scripts/plan-branch-sync.sh
+assert_file "$branch_sync_dir/8.4.json"
+assert_file "$branch_sync_dir/summary.md"
+assert_contains "$branch_sync_dir/summary.md" "safe-files-only"
+assert_contains "$branch_sync_dir/summary.md" "Blocked/manual files"
+assert_contains "$branch_sync_dir/summary.md" "Dockerfile"
+python3 - "$branch_sync_dir/8.4.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+plan = json.loads(Path(sys.argv[1]).read_text())
+assert plan["baseBranch"] == "8.5"
+assert plan["targetBranch"] == "8.4"
+assert plan["mode"] == "safe-files-only"
+assert "Dockerfile" not in plan["filesToSync"]
+assert any(item["path"] == "Dockerfile" for item in plan["blockedFiles"])
+PY
+
+BRANCH_SYNC_TARGETS="8.4" BRANCH_SYNC_OUTPUT_DIR="$branch_sync_dir" DRY_RUN=1 ./scripts/create-branch-sync-prs.sh
+assert_file "$branch_sync_dir/prs.md"
+assert_contains "$branch_sync_dir/prs.md" "Docker Hub hooks are unchanged"
+assert_contains "$branch_sync_dir/prs.md" 'Required check: `docker-smoke`'
+assert_contains "$branch_sync_dir/prs.md" "Blocked/manual files"
+assert_contains "$branch_sync_dir/prs.md" "maintenance, branch-sync, safe-sync"
+
+unsafe_allowlist="$branch_sync_dir/unsafe-safe-files.txt"
+cat > "$unsafe_allowlist" <<'EOF'
+Dockerfile
+hooks/build
+scripts/branch-drift-report.sh
+EOF
+unsafe_dir="$branch_sync_dir/unsafe"
+BRANCH_SYNC_TARGETS="8.4" BRANCH_SYNC_OUTPUT_DIR="$unsafe_dir" BRANCH_SYNC_SAFE_FILES_FILE="$unsafe_allowlist" BRANCH_SYNC_DRY_RUN=1 ./scripts/plan-branch-sync.sh
+python3 - "$unsafe_dir/8.4.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+plan = json.loads(Path(sys.argv[1]).read_text())
+assert "Dockerfile" not in plan["filesToSync"]
+assert "hooks/build" not in plan["filesToSync"]
+assert any(item["path"] == "Dockerfile" for item in plan["blockedFiles"])
+PY
+if grep -Fq "git add -A" scripts/create-branch-sync-prs.sh; then
+  fail "create-branch-sync-prs.sh must stage only planned safe files, not git add -A"
+fi
 
 fixture_dir="$(mktemp -d)"
 cat > "$fixture_dir/Dockerfile" <<'DOCKERFILE'
@@ -68,5 +124,17 @@ bash -n scripts/smoke-test-image.sh
 bash -n scripts/report-manifest.sh
 bash -n scripts/report-freshness.sh
 bash -n scripts/branch-drift-report.sh
+bash -n scripts/plan-branch-sync.sh
+bash -n scripts/create-branch-sync-prs.sh
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+p = Path('.github/workflows/branch-sync-pr.yml')
+data = yaml.safe_load(p.read_text())
+assert data.get('jobs')
+text = p.read_text()
+assert 'Dockerfile' not in text
+assert 'hooks/' not in text
+PY
 
 echo "policy script tests passed"


### PR DESCRIPTION
## Summary
- Add `branch-sync-pr` workflow for safe branch-drift sync PR generation.
- Add safe-file allowlist and blocked/manual auto-merge policy docs.
- Add `plan-branch-sync.sh` and `create-branch-sync-prs.sh` with fail-closed blocked path checks.
- Extend policy tests for safe planning, PR body safety text, unsafe allowlist rejection, and workflow parsing.

## Safety
- Docker Hub hooks remain unchanged.
- `Dockerfile`, `hooks/*`, `.dockerignore`, and publish-sensitive files are blocked from auto-sync.
- Generated sync PRs require human review; this PR does not add auto-merge.
- Sync script stages only planned safe files, not generated artifacts.

## Test Plan
- [x] `./tests/test_policy_scripts.sh`
- [x] `bash -n scripts/*.sh tests/*.sh`
- [x] `actionlint .github/workflows/*.yml`
- [x] `git diff --check`
- [x] `BRANCH_SYNC_TARGETS="8.4" BRANCH_SYNC_DRY_RUN=1 ./scripts/plan-branch-sync.sh`
- [x] `BRANCH_SYNC_TARGETS="8.4" DRY_RUN=1 ./scripts/create-branch-sync-prs.sh`
- [x] `code-review-graph update --repo .`
- [x] `code-review-graph detect-changes --repo . --base origin/8.5 --brief`
- [x] Independent code review passed
