### PR TITLE
fix: detect staged branch sync changes

### DIFF
--- a/scripts/create-branch-sync-prs.sh
+++ b/scripts/create-branch-sync-prs.sh
@@ -186,7 +186,7 @@ PY
     git checkout "origin/$BASE_BRANCH" -- "$path"
   done < "$OUTPUT_DIR/files-$target.txt"
 
-  if git diff --quiet; then
+  if git diff --quiet && git diff --cached --quiet; then
     echo "No changes after safe sync for $target" >> "$prs_md"
     git checkout "$current_branch" >/dev/null
     continue

--- a/tests/test_policy_scripts.sh
+++ b/tests/test_policy_scripts.sh
@@ -100,6 +100,7 @@ PY
 if grep -Fq "git add -A" scripts/create-branch-sync-prs.sh; then
   fail "create-branch-sync-prs.sh must stage only planned safe files, not git add -A"
 fi
+assert_contains scripts/create-branch-sync-prs.sh "git diff --cached --quiet"
 
 fixture_dir="$(mktemp -d)"
 cat > "$fixture_dir/Dockerfile" <<'DOCKERFILE'


### PR DESCRIPTION
## Summary
- Fix `create-branch-sync-prs.sh` so staged safe-sync changes are detected.
- Add policy coverage requiring `git diff --cached --quiet` in the no-op check.

## Why
`git checkout origin/8.5 -- <path>` stages added/updated files. The no-op guard only checked unstaged diff, so a target branch with staged safe-file additions could be incorrectly reported as "No changes after safe sync".

## Test Plan
- [x] `./tests/test_policy_scripts.sh`
- [x] `bash -n scripts/*.sh tests/*.sh`
- [x] `actionlint .github/workflows/*.yml`
- [x] `git diff --check`
- [x] `code-review-graph detect-changes --repo . --base origin/8.5 --brief`
