### PR TITLE
fix: dispatch smoke checks for branch sync PRs

### DIFF
--- a/.github/workflows/branch-sync-pr.yml
+++ b/.github/workflows/branch-sync-pr.yml
@@ -26,7 +26,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  actions: read
+  actions: write
 
 jobs:
   create-safe-sync-prs:
@@ -37,6 +37,7 @@ jobs:
       BRANCH_SYNC_TARGETS: ${{ github.event_name == 'workflow_dispatch' && inputs.target_branch != 'all' && inputs.target_branch || '8.0 8.1 8.2 8.3 8.4' }}
       BRANCH_SYNC_OUTPUT_DIR: branch-sync-plans
       BRANCH_SYNC_PR_LABELS: "maintenance,branch-sync,safe-sync"
+      BRANCH_SYNC_DISPATCH_WORKFLOW: "smoke-test.yml"
       DRY_RUN: "0"
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/scripts/create-branch-sync-prs.sh
+++ b/scripts/create-branch-sync-prs.sh
@@ -8,6 +8,7 @@ DRY_RUN="${DRY_RUN:-${BRANCH_SYNC_DRY_RUN:-1}}"
 LABELS="${BRANCH_SYNC_PR_LABELS:-maintenance,branch-sync,safe-sync}"
 LABELS_DISPLAY="$(printf '%s' "$LABELS" | sed 's/,/, /g')"
 BRANCH_PREFIX="${BRANCH_SYNC_BRANCH_PREFIX:-sync/branch-drift}"
+DISPATCH_WORKFLOW="${BRANCH_SYNC_DISPATCH_WORKFLOW:-}"
 REPO="${GITHUB_REPOSITORY:-woosungchoi/fpm-alpine}"
 
 usage() {
@@ -212,6 +213,11 @@ PY
       gh pr edit "$pr_url" --repo "$REPO" --add-label "$label" >/dev/null 2>&1 || true
     done
     echo "Created PR: $pr_url" >> "$prs_md"
+  fi
+
+  if [ -n "$DISPATCH_WORKFLOW" ]; then
+    gh workflow run "$DISPATCH_WORKFLOW" --repo "$REPO" --ref "$branch_name" >/dev/null
+    echo "Dispatched validation workflow $DISPATCH_WORKFLOW for $branch_name" >> "$prs_md"
   fi
 
   git checkout "$current_branch" >/dev/null

--- a/tests/test_policy_scripts.sh
+++ b/tests/test_policy_scripts.sh
@@ -41,6 +41,8 @@ assert_file scripts/create-branch-sync-prs.sh
 assert_executable scripts/create-branch-sync-prs.sh
 assert_file .github/workflows/branch-sync-pr.yml
 assert_contains .github/workflows/branch-sync-pr.yml "pull-requests: write"
+assert_contains .github/workflows/branch-sync-pr.yml "actions: write"
+assert_contains .github/workflows/branch-sync-pr.yml "BRANCH_SYNC_DISPATCH_WORKFLOW: \"smoke-test.yml\""
 assert_contains .github/workflows/branch-sync-pr.yml "actions/checkout@v6.0.2"
 assert_contains .github/workflows/branch-sync-pr.yml "type: choice"
 assert_contains .github/workflows/branch-sync-pr.yml "TARGET_BRANCH:"
@@ -101,6 +103,7 @@ if grep -Fq "git add -A" scripts/create-branch-sync-prs.sh; then
   fail "create-branch-sync-prs.sh must stage only planned safe files, not git add -A"
 fi
 assert_contains scripts/create-branch-sync-prs.sh "git diff --cached --quiet"
+assert_contains scripts/create-branch-sync-prs.sh "gh workflow run"
 
 fixture_dir="$(mktemp -d)"
 cat > "$fixture_dir/Dockerfile" <<'DOCKERFILE'


### PR DESCRIPTION
## Summary
- Give `branch-sync-pr` `actions: write` so it can dispatch validation workflows for generated PR branches.
- Dispatch `smoke-test.yml` after creating/updating each safe sync branch.
- Add policy test coverage for validation dispatch wiring.

## Why
PRs created by `GITHUB_TOKEN` do not reliably trigger normal pull_request checks. Explicitly dispatching `smoke-test.yml` attaches validation to generated branch-sync PR head SHAs.

## Test Plan
- [x] `./tests/test_policy_scripts.sh`
- [x] `bash -n scripts/*.sh tests/*.sh`
- [x] `actionlint .github/workflows/*.yml`
- [x] `git diff --check`
- [x] `code-review-graph detect-changes --repo . --base origin/8.5 --brief`
