### PR TITLE
ci: create issues for manifest verification failures

### DIFF
--- a/.github/workflows/verify-published-manifest.yml
+++ b/.github/workflows/verify-published-manifest.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 40
     permissions:
       contents: read
+      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -57,12 +58,20 @@ jobs:
           name: manifest-report-${{ strategy.job-index }}
           path: manifest-reports/
 
+      - name: Create issue on manifest verification failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_REF: ${{ matrix.image_ref }}
+        run: scripts/create-manifest-failure-issue.sh
+
   verify-single-input:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.image_ref != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
       contents: read
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -80,3 +89,10 @@ jobs:
         with:
           name: manifest-single-input
           path: manifest-reports/
+
+      - name: Create issue on manifest verification failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_REF: ${{ inputs.image_ref }}
+        run: scripts/create-manifest-failure-issue.sh

--- a/docs/ci-operations.md
+++ b/docs/ci-operations.md
@@ -22,6 +22,7 @@ Non-required / report-only workflows:
 
 - `verify-published-manifest`
   - Observes already-published Docker Hub tags.
+  - On failure, opens or updates a `manifest-failure` issue with the failed image ref and report.
   - Can be affected by Docker Hub propagation or registry/network latency.
 - `dependency-freshness`
   - Report-only dependency/source freshness observations.
@@ -77,8 +78,9 @@ Triage:
 1. Check whether the failure happened immediately after a GitHub push.
 2. If yes, suspect Docker Hub propagation lag first.
 3. Re-run the workflow manually with the same image ref after Docker Hub finishes publishing.
-4. If the tag still fails, inspect Docker Hub build/publish logs and the generated manifest report artifact.
-5. Only change publish logic after repeated manual checks prove the manifest is genuinely missing or malformed.
+4. If a `manifest-failure` issue was opened, treat it as a triage queue item and close it only after the manifest is verified or the tag is intentionally unsupported.
+5. If the tag still fails, inspect Docker Hub build/publish logs and the generated manifest report artifact.
+6. Only change publish logic after repeated manual checks prove the manifest is genuinely missing or malformed.
 
 Rollback:
 

--- a/scripts/create-manifest-failure-issue.sh
+++ b/scripts/create-manifest-failure-issue.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_REF="${IMAGE_REF:-${1:-}}"
+REPORT_DIR="${MANIFEST_REPORT_DIR:-manifest-reports}"
+REPO="${GITHUB_REPOSITORY:-}"
+RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}"
+LABEL="manifest-failure"
+
+if [ -z "$IMAGE_REF" ]; then
+  echo "IMAGE_REF or first argument is required" >&2
+  exit 64
+fi
+
+if [ -z "$REPO" ]; then
+  echo "GITHUB_REPOSITORY is required" >&2
+  exit 64
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required to create or update manifest failure issues" >&2
+  exit 69
+fi
+
+safe_name="${IMAGE_REF//[^A-Za-z0-9_.-]/_}"
+report_file="$REPORT_DIR/${safe_name}.md"
+title="Manifest verification failed: ${IMAGE_REF}"
+
+report_body="Manifest report artifact was not found at \`${report_file}\`. Check the failed workflow logs and artifacts."
+if [ -f "$report_file" ]; then
+  report_body="$(cat "$report_file")"
+fi
+
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+cat > "$body_file" <<EOF
+The published Docker image manifest verification failed for \`${IMAGE_REF}\`.
+
+- Workflow run: ${RUN_URL}
+- Image ref: \`${IMAGE_REF}\`
+- Report path: \`${report_file}\`
+
+## Triage
+
+1. If this happened soon after a push, suspect Docker Hub propagation lag first.
+2. Re-run \`verify-published-manifest\` manually for \`${IMAGE_REF}\`.
+3. Only change Docker Hub hooks or publish logic after repeated manual checks prove the manifest is genuinely missing or malformed.
+
+## Latest report
+
+${report_body}
+EOF
+
+label_args=()
+if gh label list --repo "$REPO" --json name --jq '.[].name' | grep -Fxq "$LABEL"; then
+  label_args=(--label "$LABEL")
+elif gh label create "$LABEL" --repo "$REPO" --description "Published manifest verification failures" --color "B60205" >/dev/null 2>&1; then
+  label_args=(--label "$LABEL")
+else
+  echo "warning: could not find or create label $LABEL; creating issue without label" >&2
+fi
+
+existing_issue="$(gh issue list \
+  --repo "$REPO" \
+  --state open \
+  --search "\"$title\" in:title" \
+  --json number \
+  --jq '.[0].number // empty' 2>/dev/null || true)"
+
+if [ -n "$existing_issue" ]; then
+  gh issue comment "$existing_issue" --repo "$REPO" --body-file "$body_file"
+  echo "updated existing manifest failure issue #${existing_issue} for ${IMAGE_REF}"
+else
+  gh issue create \
+    --repo "$REPO" \
+    --title "$title" \
+    --body-file "$body_file" \
+    "${label_args[@]}"
+fi

--- a/tests/test_policy_scripts.sh
+++ b/tests/test_policy_scripts.sh
@@ -123,8 +123,19 @@ assert_contains scripts/smoke-test-image.sh "run_check \"extension: imagick\""
 assert_contains scripts/smoke-test-image.sh "GITHUB_STEP_SUMMARY"
 assert_contains scripts/report-manifest.sh "MANIFEST_RETRY_ATTEMPTS"
 assert_contains scripts/report-manifest.sh "Docker Hub propagation lag"
+assert_file scripts/create-manifest-failure-issue.sh
+assert_executable scripts/create-manifest-failure-issue.sh
+assert_contains scripts/create-manifest-failure-issue.sh "gh issue create"
+assert_contains scripts/create-manifest-failure-issue.sh "gh issue comment"
+assert_contains scripts/create-manifest-failure-issue.sh "manifest-failure"
+assert_contains .github/workflows/verify-published-manifest.yml "issues: write"
+assert_contains .github/workflows/verify-published-manifest.yml "Create issue on manifest verification failure"
+assert_contains .github/workflows/verify-published-manifest.yml "scripts/create-manifest-failure-issue.sh"
+assert_contains .github/workflows/verify-published-manifest.yml "manifest-failure"
+assert_contains docs/ci-operations.md 'opens or updates a `manifest-failure` issue'
 
 bash -n scripts/smoke-test-image.sh
+bash -n scripts/create-manifest-failure-issue.sh
 bash -n scripts/report-manifest.sh
 bash -n scripts/report-freshness.sh
 bash -n scripts/branch-drift-report.sh


### PR DESCRIPTION
## Summary
- Add a manifest failure issue helper used by verify-published-manifest failures
- Grant the manifest verification jobs issues: write so failures can open/update triage issues
- Document the manifest-failure issue triage flow

## Test Plan
- ./tests/test_policy_scripts.sh
- git diff --check
- workflow YAML parse via python/yaml
- actionlint .github/workflows/*.yml
- fake gh issue-create path for scripts/create-manifest-failure-issue.sh
- code-review-graph detect-changes --repo . --base origin/8.5 --brief