### PR TITLE
ci: create dependency freshness review issues

### DIFF
--- a/.github/workflows/dependency-freshness.yml
+++ b/.github/workflows/dependency-freshness.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   report:
@@ -36,3 +37,8 @@ jobs:
         with:
           name: dependency-freshness-report
           path: freshness-reports/
+
+      - name: Create issue when dependency updates are available
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/create-dependency-freshness-issue.sh

--- a/docs/ci-operations.md
+++ b/docs/ci-operations.md
@@ -27,6 +27,7 @@ Non-required / report-only workflows:
 - `dependency-freshness`
   - Report-only dependency/source freshness observations.
   - Does not mutate Dockerfiles, open PRs, or publish images.
+  - When freshness signals require review, opens or updates a `dependency-freshness` issue.
 - `branch-drift`
   - Report-only maintained-branch drift detection.
   - Does not sync branches automatically.
@@ -104,8 +105,9 @@ Triage:
 
 1. Treat image `inspect_failed` as an observation, not an immediate CI failure.
 2. Treat PECL latest changes as manual review prompts.
-3. Keep `imagick-3.8.1` unless branch-specific smoke validation proves a different version is safe.
-4. Do not automatically update Dockerfiles from freshness output.
+3. If a `dependency-freshness` issue was opened, treat it as a manual review queue item and close it only after the candidate update is accepted, rejected, or no longer reported.
+4. Keep `imagick-3.8.1` unless branch-specific smoke validation proves a different version is safe.
+5. Do not automatically update Dockerfiles from freshness output.
 
 Rollback:
 

--- a/scripts/create-dependency-freshness-issue.sh
+++ b/scripts/create-dependency-freshness-issue.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPORT_JSON="${FRESHNESS_REPORT_JSON:-freshness-reports/dependency-freshness.json}"
+REPORT_MD="${FRESHNESS_REPORT_MD:-freshness-reports/dependency-freshness.md}"
+REPO="${GITHUB_REPOSITORY:-}"
+RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}"
+LABEL="dependency-freshness"
+
+if [ -z "$REPO" ]; then
+  echo "GITHUB_REPOSITORY is required" >&2
+  exit 64
+fi
+
+if [ ! -f "$REPORT_JSON" ]; then
+  echo "freshness report JSON not found: $REPORT_JSON" >&2
+  exit 66
+fi
+
+summary_json="$(python3 - "$REPORT_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text())
+updates = [
+    item for item in data.get("pecl", [])
+    if item.get("updateAvailable") and item.get("status") == "ok"
+]
+inspect_failures = [
+    item for item in data.get("images", [])
+    if item.get("status") == "inspect_failed"
+]
+warnings = data.get("warnings") or []
+print(json.dumps({
+    "updates": updates,
+    "inspectFailures": inspect_failures,
+    "warnings": warnings,
+    "count": len(updates) + len(inspect_failures) + len(warnings),
+}))
+PY
+)"
+
+signal_count="$(python3 - "$summary_json" <<'PY'
+import json, sys
+print(json.loads(sys.argv[1])["count"])
+PY
+)"
+
+if [ "$signal_count" = "0" ]; then
+  echo "no dependency freshness issue needed"
+  exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required to create or update dependency freshness issues" >&2
+  exit 69
+fi
+
+title="Dependency freshness review needed"
+report_body="Dependency freshness markdown report was not found at \`${REPORT_MD}\`. Check the workflow artifact."
+if [ -f "$REPORT_MD" ]; then
+  report_body="$(cat "$REPORT_MD")"
+fi
+
+body_file="$(mktemp)"
+summary_file="$(mktemp)"
+trap 'rm -f "$body_file" "$summary_file"' EXIT
+python3 - "$summary_file" "$summary_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(sys.argv[2])
+lines = []
+updates = data.get("updates", [])
+inspect_failures = data.get("inspectFailures", [])
+warnings = data.get("warnings", [])
+if updates:
+    lines.append("## PECL updates")
+    lines.append("")
+    for item in updates:
+        package = item.get("package", "unknown")
+        pinned = item.get("pinned") or "not pinned here"
+        latest = item.get("latest") or "unavailable"
+        lines.append(f"- `{package}`: pinned `{pinned}`, latest `{latest}`")
+    lines.append("")
+if inspect_failures:
+    lines.append("## Image inspect failures")
+    lines.append("")
+    for item in inspect_failures:
+        lines.append(f"- `{item.get('ref', 'unknown')}`")
+    lines.append("")
+if warnings:
+    lines.append("## Report warnings")
+    lines.append("")
+    for warning in warnings:
+        lines.append(f"- {warning}")
+    lines.append("")
+Path(sys.argv[1]).write_text("\n".join(lines).strip() + "\n")
+PY
+
+cat > "$body_file" <<EOF
+The scheduled dependency freshness report found one or more review signals.
+
+- Workflow run: ${RUN_URL}
+- JSON report: \`${REPORT_JSON}\`
+- Markdown report: \`${REPORT_MD}\`
+
+$(cat "$summary_file")
+
+## Triage
+
+1. Treat this issue as a manual review queue item, not an automatic dependency update approval.
+2. For PECL updates, run branch-specific smoke validation before changing \`IMAGICK_VERSION\` or extension install behavior.
+3. For image inspect failures, check Docker Hub/registry availability before changing source.
+4. Keep Docker Hub hooks as the publish path unless a separate publish migration is explicitly planned.
+
+## Latest report
+
+${report_body}
+EOF
+
+label_args=()
+if gh label list --repo "$REPO" --json name --jq '.[].name' | grep -Fxq "$LABEL"; then
+  label_args=(--label "$LABEL")
+elif gh label create "$LABEL" --repo "$REPO" --description "Dependency freshness review items" --color "1D76DB" >/dev/null 2>&1; then
+  label_args=(--label "$LABEL")
+else
+  echo "warning: could not find or create label $LABEL; creating issue without label" >&2
+fi
+
+existing_issue="$(gh issue list \
+  --repo "$REPO" \
+  --state open \
+  --search "\"$title\" in:title" \
+  --json number \
+  --jq '.[0].number // empty' 2>/dev/null || true)"
+
+if [ -n "$existing_issue" ]; then
+  gh issue comment "$existing_issue" --repo "$REPO" --body-file "$body_file"
+  echo "updated existing dependency freshness issue #${existing_issue}"
+else
+  gh issue create \
+    --repo "$REPO" \
+    --title "$title" \
+    --body-file "$body_file" \
+    "${label_args[@]}"
+fi

--- a/tests/test_policy_scripts.sh
+++ b/tests/test_policy_scripts.sh
@@ -119,6 +119,102 @@ assert_contains "$fixture_dir/reports/dependency-freshness.md" "Installed packag
 assert_contains "$fixture_dir/reports/dependency-freshness.md" "Manual follow-up guide"
 assert_contains "$fixture_dir/reports/dependency-freshness.md" 'Pinned Imagick: `3.8.1`'
 
+assert_file scripts/create-dependency-freshness-issue.sh
+assert_executable scripts/create-dependency-freshness-issue.sh
+assert_contains scripts/create-dependency-freshness-issue.sh "gh issue create"
+assert_contains scripts/create-dependency-freshness-issue.sh "gh issue comment"
+assert_contains scripts/create-dependency-freshness-issue.sh "dependency-freshness"
+assert_contains .github/workflows/dependency-freshness.yml "issues: write"
+assert_contains .github/workflows/dependency-freshness.yml "Create issue when dependency updates are available"
+assert_contains .github/workflows/dependency-freshness.yml "scripts/create-dependency-freshness-issue.sh"
+assert_contains docs/ci-operations.md 'opens or updates a `dependency-freshness` issue'
+
+freshness_issue_dir="$fixture_dir/freshness-issue"
+mkdir -p "$freshness_issue_dir/bin" "$freshness_issue_dir/reports"
+cat > "$freshness_issue_dir/reports/dependency-freshness.json" <<'JSON'
+{
+  "dockerfile": "Dockerfile",
+  "baseImage": "php:8.5-fpm-alpine",
+  "pinnedImagickVersion": "3.8.1",
+  "pecl": [
+    {"package": "imagick", "pinned": "3.8.1", "latest": "3.8.2", "status": "ok", "updateAvailable": true},
+    {"package": "redis", "pinned": null, "latest": "6.2.0", "status": "ok", "updateAvailable": false}
+  ],
+  "images": []
+}
+JSON
+cat > "$freshness_issue_dir/reports/dependency-freshness.md" <<'MD'
+# fpm-alpine dependency freshness report
+
+- `imagick`: pinned `3.8.1`, latest `3.8.2` (ok, update available)
+MD
+cat > "$freshness_issue_dir/bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$GH_FAKE_LOG"
+case "$*" in
+  "issue list"*) echo '' ;;
+  "label list"*) echo '' ;;
+  "label create"*) exit 0 ;;
+  "issue create"*) echo "https://github.com/woosungchoi/fpm-alpine/issues/123" ;;
+  *) echo "unexpected gh call: $*" >&2; exit 64 ;;
+esac
+GH
+chmod +x "$freshness_issue_dir/bin/gh"
+GH_FAKE_LOG="$freshness_issue_dir/gh.log" \
+PATH="$freshness_issue_dir/bin:$PATH" \
+GITHUB_REPOSITORY="woosungchoi/fpm-alpine" \
+GITHUB_RUN_ID="123456" \
+FRESHNESS_REPORT_JSON="$freshness_issue_dir/reports/dependency-freshness.json" \
+FRESHNESS_REPORT_MD="$freshness_issue_dir/reports/dependency-freshness.md" \
+./scripts/create-dependency-freshness-issue.sh
+assert_contains "$freshness_issue_dir/gh.log" "issue create"
+assert_contains "$freshness_issue_dir/gh.log" "dependency-freshness"
+
+freshness_existing_dir="$fixture_dir/freshness-existing-issue"
+mkdir -p "$freshness_existing_dir/bin" "$freshness_existing_dir/reports"
+cp "$freshness_issue_dir/reports/dependency-freshness.json" "$freshness_existing_dir/reports/dependency-freshness.json"
+cp "$freshness_issue_dir/reports/dependency-freshness.md" "$freshness_existing_dir/reports/dependency-freshness.md"
+cat > "$freshness_existing_dir/bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$GH_FAKE_LOG"
+case "$*" in
+  "issue list"*) echo '456' ;;
+  "label list"*) echo 'dependency-freshness' ;;
+  "issue comment"*) exit 0 ;;
+  *) echo "unexpected gh call: $*" >&2; exit 64 ;;
+esac
+GH
+chmod +x "$freshness_existing_dir/bin/gh"
+GH_FAKE_LOG="$freshness_existing_dir/gh.log" \
+PATH="$freshness_existing_dir/bin:$PATH" \
+GITHUB_REPOSITORY="woosungchoi/fpm-alpine" \
+GITHUB_RUN_ID="123456" \
+FRESHNESS_REPORT_JSON="$freshness_existing_dir/reports/dependency-freshness.json" \
+FRESHNESS_REPORT_MD="$freshness_existing_dir/reports/dependency-freshness.md" \
+./scripts/create-dependency-freshness-issue.sh
+assert_contains "$freshness_existing_dir/gh.log" "issue comment 456"
+if grep -Fq "issue create" "$freshness_existing_dir/gh.log"; then
+  fail "existing dependency-freshness issue should be commented on, not duplicated"
+fi
+
+freshness_no_signal_dir="$fixture_dir/freshness-no-signal"
+mkdir -p "$freshness_no_signal_dir/bin" "$freshness_no_signal_dir/reports"
+cat > "$freshness_no_signal_dir/reports/dependency-freshness.json" <<'JSON'
+{"pecl":[{"package":"imagick","pinned":"3.8.1","latest":"3.8.1","status":"ok","updateAvailable":false}],"images":[],"warnings":[]}
+JSON
+cat > "$freshness_no_signal_dir/bin/gh" <<'GH'
+#!/usr/bin/env bash
+echo "gh should not be called for no-signal freshness reports" >&2
+exit 99
+GH
+chmod +x "$freshness_no_signal_dir/bin/gh"
+PATH="$freshness_no_signal_dir/bin:$PATH" \
+GITHUB_REPOSITORY="woosungchoi/fpm-alpine" \
+FRESHNESS_REPORT_JSON="$freshness_no_signal_dir/reports/dependency-freshness.json" \
+./scripts/create-dependency-freshness-issue.sh
+
 assert_contains scripts/smoke-test-image.sh "run_check \"extension: imagick\""
 assert_contains scripts/smoke-test-image.sh "GITHUB_STEP_SUMMARY"
 assert_contains scripts/report-manifest.sh "MANIFEST_RETRY_ATTEMPTS"


### PR DESCRIPTION
## Summary
- Create/update a dependency-freshness issue when freshness reports contain review signals
- Keep dependency-freshness report-only and non-publishing
- Document triage behavior in CI operations runbook
- Cover create, existing-issue comment, and no-signal paths in policy tests

## Safety
- Docker Hub hooks remain unchanged
- Dockerfile remains unchanged
- No docker login/push or publish workflow changes

## Test Plan
- [x] ./tests/test_policy_scripts.sh
- [x] no-signal helper smoke
- [x] bash -n scripts/create-dependency-freshness-issue.sh scripts/report-freshness.sh tests/test_policy_scripts.sh
- [x] workflow YAML parse
- [x] actionlint .github/workflows/*.yml
- [x] git diff --cached --check
- [x] code-review-graph detect-changes --repo . --base origin/8.5 --brief
- [x] independent code review passed