### PR TITLE
ci: use GitHub App token for branch sync

### DIFF
--- a/.github/workflows/branch-sync-pr.yml
+++ b/.github/workflows/branch-sync-pr.yml
@@ -23,10 +23,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  actions: write
+  contents: read
 
 jobs:
   create-safe-sync-prs:
@@ -38,8 +35,8 @@ jobs:
       BRANCH_SYNC_OUTPUT_DIR: branch-sync-plans
       BRANCH_SYNC_PR_LABELS: "maintenance,branch-sync,safe-sync"
       BRANCH_SYNC_DISPATCH_WORKFLOW: "smoke-test.yml"
+      BRANCH_SYNC_ENABLE_AUTO_MERGE: "1"
       DRY_RUN: "0"
-      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Validate target branch input
         env:
@@ -51,16 +48,29 @@ jobs:
             *) echo "Unsupported target_branch: $TARGET_BRANCH" >&2; exit 64 ;;
           esac
 
+      - name: Create branch-sync GitHub App token
+        id: branch-sync-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.BRANCH_SYNC_APP_ID }}
+          private-key: ${{ secrets.BRANCH_SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: fpm-alpine
+          permission-actions: write
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - name: Checkout maintained branches
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ github.token }}
+          token: ${{ steps.branch-sync-token.outputs.token }}
 
       - name: Configure git author
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "fpm-alpine-branch-sync[bot]"
+          git config user.email "fpm-alpine-branch-sync[bot]@users.noreply.github.com"
 
       - name: Fetch maintained branch refs
         run: |
@@ -70,6 +80,8 @@ jobs:
         run: ./scripts/plan-branch-sync.sh
 
       - name: Create or update branch sync PRs
+        env:
+          GH_TOKEN: ${{ steps.branch-sync-token.outputs.token }}
         run: ./scripts/create-branch-sync-prs.sh
 
       - name: Upload branch sync plans

--- a/docs/ci-operations.md
+++ b/docs/ci-operations.md
@@ -35,6 +35,7 @@ Non-required / report-only workflows:
   - Creates safe-file sync PRs from `8.5` to maintained version branches.
   - Only copies allowlisted workflow/script/docs/test guardrails.
   - Never copies `Dockerfile`, Docker Hub hooks, or publish-sensitive files.
+  - Uses a repository-scoped GitHub App installation token and enables PR auto-merge only after validating the generated PR shape and changed files.
 
 ## Workflow responsibilities
 
@@ -139,7 +140,17 @@ Automation boundary:
 
 - Allowed: files listed in `docs/branch-sync-safe-files.txt`.
 - Blocked/manual: `Dockerfile`, Docker Hub hooks, publish-sensitive files, PHP base image lines, `IMAGICK_VERSION`, `gnu-libiconv`, and branch protection settings.
-- Merge policy: generated PRs require human review; this workflow does not auto-merge.
+- Merge policy: generated PRs are auto-merge candidates only when the workflow validates branch name, base branch, labels, and changed files against the safe-sync plan; branch protection still requires `docker-smoke` before GitHub performs the merge.
+- Token policy: `branch-sync-pr` must use a GitHub App installation token, not the default `GITHUB_TOKEN`, so PR creation/update events can trigger required checks normally.
+
+GitHub App setup:
+
+1. Create a GitHub App installed only on `woosungchoi/fpm-alpine`.
+2. Grant repository permissions: Contents read/write, Pull requests read/write, Issues read/write, and Actions read/write.
+3. Generate a private key for the app.
+4. Add repository variable `BRANCH_SYNC_APP_ID` with the numeric App ID.
+5. Add repository secret `BRANCH_SYNC_APP_PRIVATE_KEY` with the full PEM private key.
+6. Enable repository setting **Allow auto-merge** so `gh pr merge --auto --squash` can arm auto-merge while `docker-smoke` is pending.
 
 Triage:
 

--- a/scripts/create-branch-sync-prs.sh
+++ b/scripts/create-branch-sync-prs.sh
@@ -9,6 +9,9 @@ LABELS="${BRANCH_SYNC_PR_LABELS:-maintenance,branch-sync,safe-sync}"
 LABELS_DISPLAY="$(printf '%s' "$LABELS" | sed 's/,/, /g')"
 BRANCH_PREFIX="${BRANCH_SYNC_BRANCH_PREFIX:-sync/branch-drift}"
 DISPATCH_WORKFLOW="${BRANCH_SYNC_DISPATCH_WORKFLOW:-}"
+ENABLE_AUTO_MERGE="${BRANCH_SYNC_ENABLE_AUTO_MERGE:-0}"
+AUTO_MERGE_SUBJECT="${BRANCH_SYNC_AUTO_MERGE_SUBJECT:-ci: sync safe branch guardrails}"
+AUTO_MERGE_BODY="${BRANCH_SYNC_AUTO_MERGE_BODY:-Automated safe branch-sync merge after required checks pass.}"
 REPO="${GITHUB_REPOSITORY:-woosungchoi/fpm-alpine}"
 
 usage() {
@@ -113,6 +116,75 @@ is_blocked_path() {
   return 1
 }
 
+validate_pr_for_auto_merge() {
+  local pr_ref="$1"
+  local expected_target="$2"
+  local expected_head="$3"
+  local allowed_files="$4"
+  local pr_json
+  pr_json="$(mktemp)"
+  gh pr view "$pr_ref" --repo "$REPO" --json number,baseRefName,headRefName,files,labels,url > "$pr_json"
+  python3 - "$pr_json" "$expected_target" "$expected_head" "$LABELS" "$allowed_files" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+pr_path, expected_target, expected_head, labels_csv, allowed_path = sys.argv[1:]
+pr = json.loads(Path(pr_path).read_text())
+required_labels = {item.strip() for item in labels_csv.split(',') if item.strip()}
+actual_labels = {item.get('name') for item in pr.get('labels', [])}
+allowed_files = {line.strip() for line in Path(allowed_path).read_text().splitlines() if line.strip()}
+changed_files = [item['path'] for item in pr.get('files', [])]
+blocked_exact = {'Dockerfile', '.dockerignore', 'hooks', 'branch-sync-plans'}
+blocked_suffixes = ('.secret', '.pem', '.key')
+
+errors = []
+if pr.get('baseRefName') != expected_target:
+    errors.append(f"unexpected base {pr.get('baseRefName')} != {expected_target}")
+if pr.get('headRefName') != expected_head:
+    errors.append(f"unexpected head {pr.get('headRefName')} != {expected_head}")
+missing = required_labels - actual_labels
+if missing:
+    errors.append(f"missing labels: {sorted(missing)}")
+if not changed_files:
+    errors.append('no changed files')
+for path in changed_files:
+    if path in blocked_exact or path.startswith('hooks/') or path.startswith('branch-sync-plans/') or path.endswith(blocked_suffixes):
+        errors.append(f"blocked path changed: {path}")
+    if path not in allowed_files:
+        errors.append(f"path is not in this safe-sync plan: {path}")
+if errors:
+    raise SystemExit('; '.join(errors))
+print(pr['number'])
+PY
+  rm -f "$pr_json"
+}
+
+enable_auto_merge() {
+  local pr_ref="$1"
+  local expected_target="$2"
+  local expected_head="$3"
+  local allowed_files="$4"
+  [ "$ENABLE_AUTO_MERGE" = "1" ] || return 0
+
+  local pr_number
+  pr_number="$(validate_pr_for_auto_merge "$pr_ref" "$expected_target" "$expected_head" "$allowed_files")"
+  local output
+  if ! output="$(gh pr merge "$pr_number" --repo "$REPO" --squash --auto --subject "$AUTO_MERGE_SUBJECT" --body "$AUTO_MERGE_BODY" 2>&1)"; then
+    case "$output" in
+      *already*auto*merge*|*Auto-merge*already*)
+        echo "Auto-merge already enabled for PR #$pr_number" >> "$prs_md"
+        ;;
+      *)
+        printf '%s\n' "$output" >&2
+        return 1
+        ;;
+    esac
+  else
+    echo "Enabled auto-merge for PR #$pr_number" >> "$prs_md"
+  fi
+}
+
 for target in $TARGETS; do
   plan_json="$OUTPUT_DIR/$target.json"
   if [ ! -f "$plan_json" ]; then
@@ -201,8 +273,10 @@ PY
   git push origin "HEAD:$branch_name"
 
   existing_pr="$(gh pr list --repo "$REPO" --head "$branch_name" --base "$target" --state open --json number --jq '.[0].number // empty')"
+  pr_ref=""
   if [ -n "$existing_pr" ]; then
     gh pr comment "$existing_pr" --repo "$REPO" --body-file "$body_file" >/dev/null || true
+    pr_ref="$existing_pr"
     echo "Updated existing PR #$existing_pr for $target" >> "$prs_md"
   else
     pr_url="$(gh pr create --repo "$REPO" --base "$target" --head "$branch_name" --title "ci: sync safe branch guardrails to $target" --body-file "$body_file")"
@@ -212,8 +286,11 @@ PY
       [ -n "$label" ] || continue
       gh pr edit "$pr_url" --repo "$REPO" --add-label "$label" >/dev/null 2>&1 || true
     done
+    pr_ref="$pr_url"
     echo "Created PR: $pr_url" >> "$prs_md"
   fi
+
+  enable_auto_merge "$pr_ref" "$target" "$branch_name" "$OUTPUT_DIR/files-$target.txt"
 
   if [ -n "$DISPATCH_WORKFLOW" ]; then
     gh workflow run "$DISPATCH_WORKFLOW" --repo "$REPO" --ref "$branch_name" >/dev/null

--- a/tests/test_policy_scripts.sh
+++ b/tests/test_policy_scripts.sh
@@ -40,8 +40,10 @@ assert_executable scripts/plan-branch-sync.sh
 assert_file scripts/create-branch-sync-prs.sh
 assert_executable scripts/create-branch-sync-prs.sh
 assert_file .github/workflows/branch-sync-pr.yml
-assert_contains .github/workflows/branch-sync-pr.yml "pull-requests: write"
-assert_contains .github/workflows/branch-sync-pr.yml "actions: write"
+assert_contains .github/workflows/branch-sync-pr.yml "actions/create-github-app-token@v2"
+assert_contains .github/workflows/branch-sync-pr.yml "permission-pull-requests: write"
+assert_contains .github/workflows/branch-sync-pr.yml "permission-actions: write"
+assert_contains .github/workflows/branch-sync-pr.yml "BRANCH_SYNC_ENABLE_AUTO_MERGE: \"1\""
 assert_contains .github/workflows/branch-sync-pr.yml "BRANCH_SYNC_DISPATCH_WORKFLOW: \"smoke-test.yml\""
 assert_contains .github/workflows/branch-sync-pr.yml "actions/checkout@v6.0.2"
 assert_contains .github/workflows/branch-sync-pr.yml "type: choice"


### PR DESCRIPTION
## Summary
- switch branch-sync PR creation from the default GITHUB_TOKEN to a repository-scoped GitHub App installation token
- validate generated safe-sync PR shape and changed files before enabling native auto-merge
- document the GitHub App setup and update policy-script assertions

## Verification
- tests/test_policy_scripts.sh
- bash -n scripts/create-branch-sync-prs.sh tests/test_policy_scripts.sh
- parsed .github/workflows/branch-sync-pr.yml with PyYAML
- verified BRANCH_SYNC_APP_ID variable and BRANCH_SYNC_APP_PRIVATE_KEY secret exist
- verified repository allow_auto_merge=true
