### PR TITLE
ci: run branch sync daily

### DIFF
--- a/.github/workflows/branch-sync-pr.yml
+++ b/.github/workflows/branch-sync-pr.yml
@@ -16,7 +16,7 @@ on:
           - '8.3'
           - '8.4'
   schedule:
-    - cron: '37 5 * * 1'
+    - cron: '37 5 * * *'
 
 concurrency:
   group: branch-sync-pr-${{ github.ref }}-${{ inputs.target_branch || 'all' }}


### PR DESCRIPTION
## Summary
- change branch-sync-pr scheduled run from weekly to daily

## Validation
- parsed .github/workflows/branch-sync-pr.yml with PyYAML
- bash -n scripts/create-branch-sync-prs.sh scripts/plan-branch-sync.sh tests/test_policy_scripts.sh
- CRG detect-changes risk score 0.00