### PR TITLE
ci: avoid duplicate branch sync smoke dispatch

### DIFF
--- a/.github/workflows/branch-sync-pr.yml
+++ b/.github/workflows/branch-sync-pr.yml
@@ -34,7 +34,7 @@ jobs:
       BRANCH_SYNC_TARGETS: ${{ github.event_name == 'workflow_dispatch' && inputs.target_branch != 'all' && inputs.target_branch || '8.0 8.1 8.2 8.3 8.4' }}
       BRANCH_SYNC_OUTPUT_DIR: branch-sync-plans
       BRANCH_SYNC_PR_LABELS: "maintenance,branch-sync,safe-sync"
-      BRANCH_SYNC_DISPATCH_WORKFLOW: "smoke-test.yml"
+      BRANCH_SYNC_DISPATCH_WORKFLOW: ""
       BRANCH_SYNC_ENABLE_AUTO_MERGE: "1"
       DRY_RUN: "0"
     steps:

--- a/docs/ci-operations.md
+++ b/docs/ci-operations.md
@@ -142,6 +142,7 @@ Automation boundary:
 - Blocked/manual: `Dockerfile`, Docker Hub hooks, publish-sensitive files, PHP base image lines, `IMAGICK_VERSION`, `gnu-libiconv`, and branch protection settings.
 - Merge policy: generated PRs are auto-merge candidates only when the workflow validates branch name, base branch, labels, and changed files against the safe-sync plan; branch protection still requires `docker-smoke` before GitHub performs the merge.
 - Token policy: `branch-sync-pr` must use a GitHub App installation token, not the default `GITHUB_TOKEN`, so PR creation/update events can trigger required checks normally.
+- Check policy: generated PR branch pushes trigger `docker-smoke` normally; `branch-sync-pr` should not manually dispatch `smoke-test`, because duplicate check runs can leave a cancelled `docker-smoke` in the PR rollup and block native auto-merge.
 
 GitHub App setup:
 

--- a/tests/test_policy_scripts.sh
+++ b/tests/test_policy_scripts.sh
@@ -44,7 +44,7 @@ assert_contains .github/workflows/branch-sync-pr.yml "actions/create-github-app-
 assert_contains .github/workflows/branch-sync-pr.yml "permission-pull-requests: write"
 assert_contains .github/workflows/branch-sync-pr.yml "permission-actions: write"
 assert_contains .github/workflows/branch-sync-pr.yml "BRANCH_SYNC_ENABLE_AUTO_MERGE: \"1\""
-assert_contains .github/workflows/branch-sync-pr.yml "BRANCH_SYNC_DISPATCH_WORKFLOW: \"smoke-test.yml\""
+assert_contains .github/workflows/branch-sync-pr.yml "BRANCH_SYNC_DISPATCH_WORKFLOW: \"\""
 assert_contains .github/workflows/branch-sync-pr.yml "actions/checkout@v6.0.2"
 assert_contains .github/workflows/branch-sync-pr.yml "type: choice"
 assert_contains .github/workflows/branch-sync-pr.yml "TARGET_BRANCH:"


### PR DESCRIPTION
## Summary
- keep branch-sync on daily schedule
- disable manual smoke-test dispatch from branch-sync PR creation
- document why duplicate smoke-test dispatch can block native auto-merge with a cancelled check in the PR rollup

## Validation
- parsed .github/workflows/branch-sync-pr.yml with PyYAML
- bash -n scripts/create-branch-sync-prs.sh scripts/plan-branch-sync.sh tests/test_policy_scripts.sh
- tests/test_policy_scripts.sh
- CRG detect-changes risk score 0.00