### PR TITLE
ci: update generated branch sync branches safely

### DIFF
--- a/docs/ci-operations.md
+++ b/docs/ci-operations.md
@@ -143,6 +143,7 @@ Automation boundary:
 - Merge policy: generated PRs are auto-merge candidates only when the workflow validates branch name, base branch, labels, and changed files against the safe-sync plan; branch protection still requires `docker-smoke` before GitHub performs the merge.
 - Token policy: `branch-sync-pr` must use a GitHub App installation token, not the default `GITHUB_TOKEN`, so PR creation/update events can trigger required checks normally.
 - Check policy: generated PR branch pushes trigger `docker-smoke` normally; `branch-sync-pr` should not manually dispatch `smoke-test`, because duplicate check runs can leave a cancelled `docker-smoke` in the PR rollup and block native auto-merge.
+- Branch policy: `sync/branch-drift-*` branches are generated output and may be updated with `--force-with-lease`; protected maintained branches are updated only through PR merge.
 
 GitHub App setup:
 

--- a/scripts/create-branch-sync-prs.sh
+++ b/scripts/create-branch-sync-prs.sh
@@ -270,7 +270,7 @@ PY
     git add -- "$path"
   done < "$OUTPUT_DIR/files-$target.txt"
   git commit -m "ci: sync safe branch guardrails from $BASE_BRANCH"
-  git push origin "HEAD:$branch_name"
+  git push --force-with-lease origin "HEAD:$branch_name"
 
   existing_pr="$(gh pr list --repo "$REPO" --head "$branch_name" --base "$target" --state open --json number --jq '.[0].number // empty')"
   pr_ref=""

--- a/tests/test_policy_scripts.sh
+++ b/tests/test_policy_scripts.sh
@@ -106,6 +106,7 @@ if grep -Fq "git add -A" scripts/create-branch-sync-prs.sh; then
 fi
 assert_contains scripts/create-branch-sync-prs.sh "git diff --cached --quiet"
 assert_contains scripts/create-branch-sync-prs.sh "gh workflow run"
+assert_contains scripts/create-branch-sync-prs.sh "git push --force-with-lease origin"
 
 fixture_dir="$(mktemp -d)"
 cat > "$fixture_dir/Dockerfile" <<'DOCKERFILE'


### PR DESCRIPTION
## Summary
- use git push --force-with-lease for generated sync/branch-drift-* branches
- document that maintained branches are still updated only through PR merge
- add policy assertion for the generated-branch update behavior

## Validation
- parsed .github/workflows/branch-sync-pr.yml with PyYAML
- bash -n scripts/create-branch-sync-prs.sh scripts/plan-branch-sync.sh tests/test_policy_scripts.sh
- tests/test_policy_scripts.sh
- CRG detect-changes risk score 0.00