### PR TITLE
docs: align lifecycle and repository governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Report a reproducible non-security problem with an image
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not disclose vulnerabilities or secrets here. Use the private reporting route in SECURITY.md instead.
+  - type: input
+    id: image
+    attributes:
+      label: Image tag
+      description: Use an explicit tag, for example woosungchoi/fpm-alpine:8.5.
+      placeholder: woosungchoi/fpm-alpine:8.5
+    validations:
+      required: true
+  - type: input
+    id: architecture
+    attributes:
+      label: Architecture
+      placeholder: linux/amd64 or linux/arm64
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem
+      description: What happened, and what did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest safe reproducer. Remove credentials and other sensitive data.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste only non-sensitive log excerpts.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I confirmed this tag is supported according to SUPPORT.md.
+          required: true
+        - label: This report contains no vulnerability details, credentials, tokens, or other secrets.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability privately
+    url: https://github.com/woosungchoi/fpm-alpine/security/advisories/new
+    about: Use GitHub private vulnerability reporting. Read SECURITY.md before submitting; never put vulnerability details or secrets in a public issue.
+  - name: Security policy
+    url: https://github.com/woosungchoi/fpm-alpine/security/policy
+    about: Review supported versions and private reporting guidance.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+# Pull request
+
+## Summary
+
+Describe the change and why it is needed.
+
+## Scope
+
+- [ ] The target PHP branch is identified.
+- [ ] Image build or runtime behavior changes are called out explicitly.
+- [ ] Docker Hub hooks and publishing behavior are unchanged, or the change is clearly justified.
+
+## Verification
+
+- [ ] `./tests/test_policy_scripts.sh`
+- [ ] `bash -n scripts/*.sh tests/*.sh`
+- [ ] Relevant image smoke test, when build behavior changes
+
+## Policy
+
+- [ ] Documentation agrees with [SUPPORT.md](https://github.com/woosungchoi/fpm-alpine/blob/HEAD/SUPPORT.md).
+- [ ] No vulnerability details or secrets are included in this PR.
+- [ ] Suspected vulnerabilities are reported only through [GitHub private vulnerability reporting](https://github.com/woosungchoi/fpm-alpine/security/advisories/new), never in a public issue or PR.

--- a/BRANCH-AND-TAG-POLICY.md
+++ b/BRANCH-AND-TAG-POLICY.md
@@ -1,106 +1,42 @@
 # Branch and tag policy
 
-This document defines the repository policy after retiring PHP 7.4 / `master` from active support.
+This document defines branch and tag behavior. [SUPPORT.md](./SUPPORT.md) is the canonical source for version lifecycle status and EOL dates.
 
-## Current policy
+## Branch roles
 
-This repository uses **version branches as the active supported lines**.
+- `8.5` is the current primary and GitHub default branch.
+- Version branches identify their matching PHP major/minor image line.
+- A branch or tag existing in the repository or registry does not by itself mean that the line is supported.
+- PHP 7.4 / former `master` is frozen, unsupported history; the remote `master` branch has been removed.
 
-### Active supported branches
+Support, security-only, frozen, and unsupported status is defined only in [SUPPORT.md](./SUPPORT.md). In particular, the retained `8.0` and `8.1` tags are unsupported and never rebuilt.
 
-- `8.0`
-- `8.1`
-- `8.2`
-- `8.3`
-- `8.4`
-- `8.5`
+## Docker Hub tag policy
 
-### Primary branch
+- Production users should pin an explicit tag such as `woosungchoi/fpm-alpine:8.5`.
+- There is intentionally no `latest` tag. Consumers must select a PHP line explicitly.
+- Docker Hub hooks remain the publish path for supported release targets.
+- GitHub Actions verifies, observes, and reports; it does not replace Docker Hub publishing.
+- Operational workflows may still inspect historical tags. Such inspection does not grant or imply support.
 
-- **current stable/mainline branch:** `8.5`
-- **GitHub default branch:** `8.5`
+## Change policy
 
-### Legacy branch history
+- New development starts from the primary branch or the supported target branch that needs the change.
+- Security-only branches receive security fixes and only the minimum maintenance required to deliver them.
+- Frozen branches receive no rebuilds, dependency refreshes, CVE remediation, or compatibility fixes.
+- Publish-sensitive changes, Dockerfiles, and Docker Hub hooks require explicit branch-specific review and image validation.
+- Safe workflow, script, test, and policy guardrails may be synchronized under the controls documented in the CI runbook.
 
-- `master` was the old **PHP 7.4** branch
-- PHP 7.4 / `master` is **no longer maintained or updated**
-- the remote `master` branch has already been removed
-- legacy `master` history may still be preserved locally under an archive ref for historical reference
+## Imagick baseline
 
-## What each branch should mean
+Supported branches use the following baseline unless a branch-specific, smoke-tested exception is documented:
 
-### `8.5`
+- pinned release: `imagick-3.8.1`
+- source: PECL release tarball copied to `/usr/src/php/ext/imagick`
+- build: `docker-php-ext-install imagick`
 
-`8.5` is the branch that should currently be treated as the repository's primary line.
+Do not infer ongoing support for a frozen image merely because its historical Dockerfile used this baseline.
 
-That means:
+## CI and operations
 
-- users should land on `8.5` by default
-- new documentation should describe `8.5` as the mainline
-- if Docker Hub keeps a `latest` tag, it should follow `8.5`
-- when the main supported PHP line advances in the future, this role should move forward to the next stable branch
-
-### `8.0` through `8.4`
-
-These are still supported version branches for users who intentionally pin those lines.
-
-They remain active build targets, but they are not the conceptual default branch.
-
-### legacy `master`
-
-The old PHP 7.4 line should no longer be used for current development, release signaling, or Docker Hub active branch builds.
-
-Recommended treatment:
-
-- preserve it only as archived history if needed
-- do not advertise it as supported
-- do not route `latest` through it
-- do not revive it for new work
-
-## Docker Hub branch/tag policy
-
-The repository-side policy is now:
-
-- active automated branch builds target **`8.0` through `8.5`**
-- the legacy PHP 7.4 `master` line is **not part of the active branch set**
-- explicit version tags remain the production-safe recommendation
-- if Docker Hub publishes a `latest` tag, `latest` should point to the same image line as the current primary/default branch: **`8.5`**
-
-## Current state
-
-### Already true
-
-- supported branches are **`8.0` through `8.5`**
-- docs treat **`8.5`** as the current mainline
-- PHP 7.4 / `master` is no longer an actively maintained line
-- GitHub default branch is **`8.5`**
-- remote `master` has been deleted
-
-### Still worth verifying operationally
-
-- Docker Hub automated build rules are limited to **`8.0` through `8.5`**
-- Docker Hub `latest` behavior follows **`8.5`** if `latest` is still published
-
-## Operational recommendation
-
-- tell users to pin explicit tags such as `woosungchoi/fpm-alpine:8.5`
-- treat `8.5` as the mainline in docs and internal references
-- avoid new work on legacy PHP 7.4 history
-- treat PHP 7.4 as frozen / unsupported here
-- keep Docker Hub hooks as the publish path; use GitHub Actions for verification, observation, and report-only guardrails
-- keep `docker-smoke` as the required branch-protection check, while manifest/freshness/drift workflows remain non-required reports
-
-## CI / operations runbook
-
-See [docs/ci-operations.md](./docs/ci-operations.md) for the maintained branch protection model, workflow triage steps, report-only workflow policy, and rollback procedure.
-
-
-## Maintained Imagick baseline
-
-For the actively supported PHP branches **`8.0` through `8.5`**, the repository policy is now:
-
-- use **`imagick-3.8.1`** as the pinned release
-- install from the **PECL release tarball** into `/usr/src/php/ext/imagick`
-- compile with **`docker-php-ext-install imagick`**
-
-If a future branch needs a different Imagick version, document that as an explicit exception instead of expanding a version matrix in multiple files.
+See [docs/ci-operations.md](./docs/ci-operations.md) for branch protection, report-only workflow boundaries, triage, and rollback procedures.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,353 @@
+SPDX-License-Identifier: GPL-2.0-only
+
+Repository licensing and upstream attribution
+
+This repository is distributed under the GNU General Public License,
+version 2 only (GPL-2.0-only), whose full text follows.
+
+This image has historical lineage and/or incorporates techniques from the
+WordPress Docker Official Image. docker-library/wordpress is licensed under
+GPL-2.0. It also builds on the PHP Docker Official Image packaging.
+docker-library/php is licensed under the MIT License. Those upstream projects
+retain their own copyrights and license notices. This notice identifies provenance;
+it does not claim ownership of upstream work or alter upstream licenses.
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 
 Custom PHP-FPM Alpine images used for WordPress / Gnuboard / Rhymix deployments.
 
-See also: [BRANCH-AND-TAG-POLICY.md](./BRANCH-AND-TAG-POLICY.md) and [docs/ci-operations.md](./docs/ci-operations.md).
+See also: [SUPPORT.md](./SUPPORT.md), [BRANCH-AND-TAG-POLICY.md](./BRANCH-AND-TAG-POLICY.md), and [docs/ci-operations.md](./docs/ci-operations.md).
 
 > [!IMPORTANT]
-> This repository's **actively supported image lines** are the version branches **`8.0` through `8.5`**.
->
-> **PHP 7.4 / legacy `master` is no longer actively maintained or updated.**
+> PHP `8.0` and `8.1` images are frozen, unsupported legacy artifacts and are never rebuilt. See [SUPPORT.md](./SUPPORT.md) for the canonical lifecycle policy.
 >
 > The repository's current primary/default branch is **`8.5`**.
 >
@@ -15,16 +13,16 @@ See also: [BRANCH-AND-TAG-POLICY.md](./BRANCH-AND-TAG-POLICY.md) and [docs/ci-op
 
 ## Current branch / version map
 
-### Active supported branches
+### Version branches
 
 | Branch | Base image | Status |
 | --- | --- | --- |
-| `8.0` | `php:8.0-fpm-alpine` | supported |
-| `8.1` | `php:8.1-fpm-alpine` | supported |
-| `8.2` | `php:8.2-fpm-alpine` | supported |
-| `8.3` | `php:8.3-fpm-alpine` | supported |
-| `8.4` | `php:8.4-fpm-alpine` | supported |
-| `8.5` | `php:8.5-fpm-alpine` | supported / primary branch |
+| `8.0` | `php:8.0-fpm-alpine` | EOL / frozen / unsupported |
+| `8.1` | `php:8.1-fpm-alpine` | EOL / frozen / unsupported |
+| `8.2` | `php:8.2-fpm-alpine` | security-only |
+| `8.3` | `php:8.3-fpm-alpine` | security-only |
+| `8.4` | `php:8.4-fpm-alpine` | active / security support |
+| `8.5` | `php:8.5-fpm-alpine` | active / security support; primary branch |
 
 ### Legacy branch
 
@@ -34,27 +32,20 @@ See also: [BRANCH-AND-TAG-POLICY.md](./BRANCH-AND-TAG-POLICY.md) and [docs/ci-op
 
 ## Support and branch policy
 
-This repository now follows a simple policy:
-
-- actively maintained PHP lines live on version branches **`8.0` through `8.5`**
-- **`8.5` is the current primary/default branch** for the repository
-- legacy `master` is a **PHP 7.4 historical line** and is no longer part of the active remote branch set
-- **PHP 7.4 is no longer updated in this repository**
-- Docker Hub automated builds are intended for the supported branches **`8.0` through `8.5`**
+The canonical support matrix and definitions are in [SUPPORT.md](./SUPPORT.md). `8.5` is the primary/default branch. PHP 7.4 / legacy `master`, PHP 8.0, and PHP 8.1 are unsupported frozen history.
 
 What that means in practice:
 
 - browse and document the repo as if **`8.5` is the mainline**
-- use older version branches only when you intentionally need that exact PHP line
+- use only a supported version branch for new deployments
 - do **not** start new work from the legacy PHP 7.4 branch history
 - do **not** expect PHP 7.4 fixes or refreshes going forward
 
 ## Docker tags / Docker Hub notes
 
-- Supported automated branch builds should target **`8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5`**
-- The legacy PHP 7.4 `master` line is no longer part of the active remote branch set
+- PHP 8.0 and 8.1 tags are retained but never rebuilt
 - Explicit version tags remain the safest production contract
-- If Docker Hub publishes `latest`, it should follow the same image line as the primary/default branch: **`8.5`**
+- No `latest` tag is intentionally published
 
 Safe rule for production use:
 
@@ -81,7 +72,7 @@ This keeps Docker Hub autobuild hooks in place while making the final published 
 `dependency-freshness` is a report-only workflow. It does not publish images or update pins automatically. It records:
 
 - the current Dockerfile base image digest,
-- the published Docker Hub tag digests for maintained branches `8.0` through `8.5`,
+- the published Docker Hub tag digests covered by the workflow configuration,
 - PECL latest-version observations for `imagick`, `redis`, and `apcu`, and
 - whether the Alpine `gnu-libiconv` / `LD_PRELOAD` workaround is still present and should be periodically reassessed.
 
@@ -90,14 +81,14 @@ The workflow runs weekly and on manual dispatch, writes a GitHub Actions step su
 This repository is maintained through version branches and lightweight verification workflows:
 
 - `smoke-test` builds the branch Dockerfile and validates PHP/FPM runtime basics, required extensions, `ffmpeg`, `iconv`, and `Imagick` behavior.
-- `verify-published-manifest` runs on a schedule and verifies the published Docker Hub tags for maintained branches.
+- `verify-published-manifest` runs on a schedule and verifies the configured published Docker Hub tags.
 - `dependency-freshness` produces report-only dependency/source freshness observations for maintainers.
-- `branch-drift` produces report-only workflow/script/policy drift reports across maintained branches.
-- `branch-sync-pr` can create safe-file sync PRs from `8.5` to maintained branches for workflow/script/docs/test guardrails only.
-- Maintained branches use the documented Imagick baseline in [BRANCH-AND-TAG-POLICY.md](./BRANCH-AND-TAG-POLICY.md).
+- `branch-drift` produces report-only workflow/script/policy drift reports across configured branches.
+- `branch-sync-pr` can create safe-file sync PRs from `8.5` for workflow/script/docs/test guardrails only; operational coverage does not imply lifecycle support.
+- Supported branches use the documented Imagick baseline in [BRANCH-AND-TAG-POLICY.md](./BRANCH-AND-TAG-POLICY.md).
 - Security reporting and supported-version policy are documented in [SECURITY.md](./SECURITY.md).
 
-GitHub Releases are intentionally optional for this Docker image repository. The operational release contract is the explicit Docker image tag for each maintained PHP version branch.
+GitHub Releases are intentionally optional for this Docker image repository. The operational release contract is the explicit Docker image tag for each supported PHP version branch.
 
 ## What this image adds
 
@@ -114,7 +105,7 @@ You can convert animated `gif` images to `mp4` or `webm` with `ffmpeg`.
 
 ## Imagick policy
 
-For the maintained branches **`8.0` through `8.5`**, this repository now standardizes on:
+For supported branches, this repository standardizes on:
 
 - pinned `imagick` release: **`3.8.1`**
 - install method: **PECL release tarball + `docker-php-ext-install imagick`**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,19 +2,7 @@
 
 ## Supported versions
 
-This repository publishes custom PHP-FPM Alpine images for the maintained PHP version branches `8.0` through `8.5`.
-
-The current primary/default branch is `8.5`. The legacy PHP 7.4 / `master` line is no longer maintained by this repository.
-
-| Branch | Base image | Status |
-| --- | --- | --- |
-| `8.0` | `php:8.0-fpm-alpine` | supported |
-| `8.1` | `php:8.1-fpm-alpine` | supported |
-| `8.2` | `php:8.2-fpm-alpine` | supported |
-| `8.3` | `php:8.3-fpm-alpine` | supported |
-| `8.4` | `php:8.4-fpm-alpine` | supported |
-| `8.5` | `php:8.5-fpm-alpine` | supported / primary branch |
-| legacy `master` | `php:7.4-fpm-alpine` | unsupported / frozen history |
+See [SUPPORT.md](./SUPPORT.md) for the canonical supported-version matrix, lifecycle definitions, and EOL policy. Reports for frozen or EOL tags may be closed without a repository fix.
 
 Production users should pin an explicit version tag, for example `woosungchoi/fpm-alpine:8.5`, instead of relying on `latest`.
 
@@ -24,11 +12,11 @@ The maintained image lines are validated with repository smoke tests and publish
 
 - `smoke-test` builds the branch Dockerfile and verifies PHP/FPM runtime basics, required extensions, `ffmpeg`, `iconv`, and `Imagick` behavior.
 - `verify-published-manifest` checks the published Docker Hub tags for required multi-arch manifest entries.
-- The repository policy standardizes maintained branches on the documented Imagick release baseline unless a branch-specific exception is documented.
+- The repository policy standardizes supported branches on the documented Imagick release baseline unless a branch-specific exception is documented.
 
 ## Reporting a vulnerability
 
-Please report suspected vulnerabilities privately through GitHub Security Advisories for this repository when available. If advisories are not available to you, contact the maintainer through the GitHub profile linked from this repository.
+Report suspected vulnerabilities through [GitHub private vulnerability reporting](https://github.com/woosungchoi/fpm-alpine/security/advisories/new). Do not include vulnerability details, credentials, tokens, or other secrets in a public issue.
 
 Please include:
 
@@ -38,7 +26,7 @@ Please include:
 - expected impact
 - relevant upstream CVE or advisory links, if known
 
-Do not open a public issue for a vulnerability until a fix or mitigation is available.
+If private vulnerability reporting is unavailable, use the maintainer contact information on the repository owner's GitHub profile without disclosing details publicly. Do not open a public issue for a vulnerability until a fix or mitigation is available.
 
 ## Maintainer response
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,28 @@
+# Support policy
+
+This file is the canonical lifecycle and support policy for the image tags in this repository. PHP lifecycle dates below follow the upstream PHP supported-versions schedule. Repository support cannot extend beyond upstream support.
+
+## Version lifecycle
+
+| Image tag / branch | Repository status | Upstream end of life |
+| --- | --- | --- |
+| PHP 8.0 (`8.0`) | EOL, frozen, unsupported | 2023-11-26 |
+| PHP 8.1 (`8.1`) | EOL, frozen, unsupported | 2025-12-31 |
+| PHP 8.2 (`8.2`) | security-only | 2026-12-31 |
+| PHP 8.3 (`8.3`) | security-only | 2027-12-31 |
+| PHP 8.4 (`8.4`) | active support, then security support | 2028-12-31 |
+| PHP 8.5 (`8.5`) | active support, then security support; primary branch | 2029-12-31 |
+
+“Security-only” means changes are limited to security fixes and the minimum maintenance needed to deliver them. “Active support” includes compatible bug fixes and security fixes. Support ends when the listed upstream EOL date is reached.
+
+## Unsupported legacy images
+
+The `8.0` and `8.1` tags are retained so existing references and historical artifacts remain identifiable, but they are frozen and **never rebuilt**. They receive no package refreshes, CVE remediation, compatibility fixes, or support. Running these tags is unsupported legacy use and should be migrated to a supported PHP line.
+
+The former PHP 7.4 / `master` line is also frozen, unsupported history and is not an active remote branch.
+
+The Docker Hub `this` tag is an unsupported legacy/accidental tag; it is not a supported version contract, receives no rebuilds, updates, or support, and must not be used.
+
+## Tag policy
+
+There is intentionally no `latest` tag. Pin an explicit major/minor image tag, such as `woosungchoi/fpm-alpine:8.5`, and review this policy before selecting a line. Retaining a tag does not imply that it is supported or rebuilt.

--- a/docs/archive/PHASE4-PHASE5.md
+++ b/docs/archive/PHASE4-PHASE5.md
@@ -1,5 +1,9 @@
 # Phase 4 / Phase 5 progress notes
 
+> **ARCHIVED — NON-AUTHORITATIVE — SUPERSEDED:** This progress note is historical evidence only. **All support, branch, tag, `latest`, branch-sync, and publisher instructions below are historical only and MUST NOT be followed.** Current policy and operations supersede them: [SUPPORT.md](../../SUPPORT.md), [BRANCH-AND-TAG-POLICY.md](../../BRANCH-AND-TAG-POLICY.md), and [CI operations](../ci-operations.md).
+>
+> Superseded assumptions: `8.0`/`8.1` are frozen EOL artifacts that are never rebuilt; no `latest` tag is published; the old single-trunk migration target for `8.2`–`8.5` is not current policy.
+
 ## Phase 4 — build verification / smoke coverage
 
 Implemented:

--- a/docs/archive/REFACTORING-TODO.md
+++ b/docs/archive/REFACTORING-TODO.md
@@ -1,5 +1,9 @@
 # fpm-alpine refactoring roadmap
 
+> **ARCHIVED — NON-AUTHORITATIVE — SUPERSEDED:** This completed roadmap is historical evidence only. **All support, branch, tag, `latest`, branch-sync, and publisher instructions below are historical only and MUST NOT be followed.** Current policy and operations supersede them: [SUPPORT.md](../../SUPPORT.md), [BRANCH-AND-TAG-POLICY.md](../../BRANCH-AND-TAG-POLICY.md), and [CI operations](../ci-operations.md).
+>
+> Superseded assumptions: `8.0`/`8.1` are frozen EOL artifacts that are never rebuilt; no `latest` tag is published; the old single-trunk migration target for `8.2`–`8.5` is not current policy.
+
 This document records the cleanup direction used to reduce branch/version drift without mixing legacy PHP 7.4 implementation history into the active lines.
 
 ## Goals

--- a/docs/ci-operations.md
+++ b/docs/ci-operations.md
@@ -5,14 +5,14 @@ This runbook explains how `woosungchoi/fpm-alpine` uses GitHub Actions around th
 ## One-screen summary
 
 - Default branch: `8.5`
-- Maintained branches: `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5`
-- Legacy `master` / PHP 7.4: not active
+- Lifecycle policy: [SUPPORT.md](../SUPPORT.md) is canonical; workflow coverage does not imply support
+- Frozen legacy lines are not release targets
 - Docker Hub hooks remain the publish path. GitHub Actions verifies, observes, and reports; it does not replace Docker Hub publishing.
 - Production users should pin explicit image tags such as `woosungchoi/fpm-alpine:8.5`.
 
 ## Required status check
 
-The branch protection required check for maintained branches is the `smoke-test` workflow job named:
+The branch protection required check for branches accepting changes is the `smoke-test` workflow job named:
 
 - `docker-smoke`
 
@@ -96,7 +96,7 @@ Purpose: Report dependency freshness without automatic mutation.
 The report includes:
 
 - Dockerfile base image digest
-- maintained Docker Hub tag digests
+- configured Docker Hub tag digests
 - PECL latest observations for `imagick`, `redis`, and `apcu`
 - installed package signals parsed from the Dockerfile
 - `gnu-libiconv` workaround status
@@ -117,7 +117,7 @@ Rollback:
 
 ### `branch-drift`
 
-Purpose: Detect missing workflow/script/policy changes across maintained branches.
+Purpose: Detect missing workflow/script/policy changes across configured branches. This operational coverage does not imply lifecycle support.
 
 Triage:
 
@@ -134,7 +134,7 @@ Rollback:
 
 ### `branch-sync-pr`
 
-Purpose: Create safe-file sync PRs from `8.5` to maintained branches `8.0` through `8.4` when report-only branch drift identifies missing guardrails.
+Purpose: Create safe-file sync PRs from `8.5` to configured version branches when report-only branch drift identifies missing guardrails. This operational coverage does not imply lifecycle support.
 
 Automation boundary:
 
@@ -176,7 +176,7 @@ Before merging CI/workflow changes:
 - Workflow YAML has explicit minimal permissions.
 - Report-only workflows are not marked as required checks.
 - Docker Hub publish hooks are unchanged unless the task is explicitly a publish migration.
-- README, branch policy, and this runbook agree on the maintained branch set.
+- README, branch policy, and this runbook defer lifecycle status to `SUPPORT.md`.
 - Rollback is limited to GitHub Actions/docs/scripts when publish behavior is untouched.
 
 ## Manual commands

--- a/tests/test_policy_scripts.sh
+++ b/tests/test_policy_scripts.sh
@@ -14,6 +14,11 @@ assert_file() {
   [ -f "$path" ] || fail "expected file $path to exist"
 }
 
+assert_not_file() {
+  local path="$1"
+  [ ! -e "$path" ] || fail "expected $path not to exist"
+}
+
 assert_executable() {
   local path="$1"
   [ -x "$path" ] || fail "expected $path to be executable"
@@ -22,10 +27,131 @@ assert_executable() {
 assert_contains() {
   local path="$1"
   local needle="$2"
-  grep -Fq "$needle" "$path" || fail "expected $path to contain: $needle"
+  grep -Fq -- "$needle" "$path" || fail "expected $path to contain: $needle"
 }
 
-assert_file docs/ci-operations.md
+assert_not_contains() {
+  local path="$1"
+  local needle="$2"
+  ! grep -Fq -- "$needle" "$path" || fail "expected $path not to contain: $needle"
+}
+
+assert_regex() {
+  local path="$1"
+  local pattern="$2"
+  grep -Eq -- "$pattern" "$path" || fail "expected $path to match regex: $pattern"
+}
+
+assert_not_regex() {
+  local path="$1"
+  local pattern="$2"
+  ! grep -Eiq -- "$pattern" "$path" || fail "expected $path not to match regex: $pattern"
+}
+
+assert_file SUPPORT.md
+assert_regex SUPPORT.md '^\| PHP 8\.0 \(`8\.0`\) \| EOL, frozen, unsupported \| 2023-11-26 \|$'
+assert_regex SUPPORT.md '^\| PHP 8\.1 \(`8\.1`\) \| EOL, frozen, unsupported \| 2025-12-31 \|$'
+assert_regex SUPPORT.md '^\| PHP 8\.2 \(`8\.2`\) \| security-only \| 2026-12-31 \|$'
+assert_regex SUPPORT.md '^\| PHP 8\.3 \(`8\.3`\) \| security-only \| 2027-12-31 \|$'
+assert_regex SUPPORT.md '^\| PHP 8\.4 \(`8\.4`\) \| active support, then security support \| 2028-12-31 \|$'
+assert_regex SUPPORT.md '^\| PHP 8\.5 \(`8\.5`\) \| active support, then security support; primary branch \| 2029-12-31 \|$'
+assert_regex SUPPORT.md 'The `8\.0` and `8\.1` tags are retained.*frozen and \*\*never rebuilt\*\*'
+assert_contains SUPPORT.md "Running these tags is unsupported legacy use"
+assert_contains SUPPORT.md 'The Docker Hub `this` tag is an unsupported legacy/accidental tag; it is not a supported version contract, receives no rebuilds, updates, or support, and must not be used.'
+assert_contains SUPPORT.md 'There is intentionally no `latest` tag.'
+
+assert_file LICENSE
+license_sha256="c894d4253148e8ce9803b6a114a6bb330e65ac358afe03e1f39e851d3ebf03c6"
+actual_license_sha256="$(sha256sum -- LICENSE | cut -d ' ' -f 1)"
+[ "$actual_license_sha256" = "$license_sha256" ] || fail "LICENSE SHA-256 mismatch: expected $license_sha256, got $actual_license_sha256"
+assert_contains LICENSE "SPDX-License-Identifier: GPL-2.0-only"
+assert_regex LICENSE '^WordPress Docker Official Image\. docker-library/wordpress is licensed under$'
+assert_regex LICENSE '^GPL-2\.0\. It also builds on the PHP Docker Official Image packaging\.$'
+assert_regex LICENSE '^docker-library/php is licensed under the MIT License\.'
+assert_contains LICENSE "GNU GENERAL PUBLIC LICENSE"
+assert_contains LICENSE "Version 2, June 1991"
+assert_contains LICENSE "TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION"
+assert_contains LICENSE "0. This License applies to any program or other work"
+assert_contains LICENSE "12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW"
+assert_contains LICENSE "END OF TERMS AND CONDITIONS"
+
+private_advisory_url="https://github.com/woosungchoi/fpm-alpine/security/advisories/new"
+support_url="https://github.com/woosungchoi/fpm-alpine/blob/HEAD/SUPPORT.md"
+security_policy_url="https://github.com/woosungchoi/fpm-alpine/security/policy"
+assert_file .github/PULL_REQUEST_TEMPLATE.md
+assert_contains .github/PULL_REQUEST_TEMPLATE.md "Docker Hub hooks and publishing behavior are unchanged"
+assert_contains .github/PULL_REQUEST_TEMPLATE.md "No vulnerability details or secrets are included"
+assert_contains .github/PULL_REQUEST_TEMPLATE.md "$private_advisory_url"
+assert_contains .github/PULL_REQUEST_TEMPLATE.md "$support_url"
+assert_contains .github/PULL_REQUEST_TEMPLATE.md "never in a public issue or PR"
+assert_file .github/ISSUE_TEMPLATE/bug-report.yml
+assert_contains .github/ISSUE_TEMPLATE/bug-report.yml "Do not disclose vulnerabilities or secrets here"
+python3 - .github/ISSUE_TEMPLATE/bug-report.yml <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+lines = path.read_text().splitlines()
+starts = [i for i, line in enumerate(lines) if re.match(r"^  - type: ", line)]
+blocks = [lines[start:end] for start, end in zip(starts, starts[1:] + [len(lines)])]
+by_id = {}
+for block in blocks:
+    ids = [re.fullmatch(r"    id: ([A-Za-z0-9_-]+)", line) for line in block]
+    ids = [match.group(1) for match in ids if match]
+    if len(ids) == 1:
+        by_id[ids[0]] = block
+
+for field in ("image", "architecture", "description", "reproduction"):
+    block = by_id.get(field)
+    if block is None:
+        raise SystemExit(f"FAIL: bug form is missing core field id: {field}")
+    try:
+        validations = block.index("    validations:")
+    except ValueError:
+        raise SystemExit(f"FAIL: bug form field {field} is missing its validations block")
+    if "      required: true" not in block[validations + 1:]:
+        raise SystemExit(f"FAIL: bug form field {field} must be individually required")
+
+checks = by_id.get("checks")
+if checks is None:
+    raise SystemExit("FAIL: bug form is missing safety confirmations id: checks")
+if sum(line == "          required: true" for line in checks) != 2:
+    raise SystemExit("FAIL: both bug form safety confirmations must be required")
+PY
+assert_file .github/ISSUE_TEMPLATE/config.yml
+assert_regex .github/ISSUE_TEMPLATE/config.yml '^blank_issues_enabled: false$'
+assert_contains .github/ISSUE_TEMPLATE/config.yml "$private_advisory_url"
+assert_contains .github/ISSUE_TEMPLATE/config.yml "$security_policy_url"
+assert_contains SECURITY.md "$private_advisory_url"
+assert_contains SECURITY.md "Do not open a public issue for a vulnerability"
+
+assert_not_file PHASE4-PHASE5.md
+assert_not_file REFACTORING-TODO.md
+for archive in docs/archive/PHASE4-PHASE5.md docs/archive/REFACTORING-TODO.md; do
+  assert_file "$archive"
+  assert_contains "$archive" "ARCHIVED — NON-AUTHORITATIVE — SUPERSEDED"
+  assert_contains "$archive" "MUST NOT be followed"
+  assert_contains "$archive" "../../SUPPORT.md"
+  assert_contains "$archive" "../../BRANCH-AND-TAG-POLICY.md"
+  assert_contains "$archive" "../ci-operations.md"
+  assert_contains "$archive" '8.0`/`8.1'
+  assert_contains "$archive" 'no `latest` tag is published'
+done
+
+for active_doc in README.md SECURITY.md BRANCH-AND-TAG-POLICY.md docs/ci-operations.md; do
+  assert_file "$active_doc"
+  assert_contains "$active_doc" "SUPPORT.md"
+  assert_not_regex "$active_doc" '20[0-9]{2}-[0-9]{2}-[0-9]{2}'
+  assert_not_regex "$active_doc" 'latest tag (exists|is published|points|maps|follows)'
+  assert_not_regex "$active_doc" '8\.0.*8\.1.*(are|remain) (active|maintained|supported)'
+done
+assert_contains README.md "canonical lifecycle policy"
+assert_contains SECURITY.md "canonical supported-version matrix"
+assert_contains BRANCH-AND-TAG-POLICY.md "canonical source for version lifecycle status and EOL dates"
+assert_contains docs/ci-operations.md "Lifecycle policy: [SUPPORT.md](../SUPPORT.md) is canonical"
+assert_not_contains README.md "future target is version branches"
+assert_not_contains BRANCH-AND-TAG-POLICY.md "future target is version branches"
 assert_contains docs/ci-operations.md "Required status check"
 assert_contains docs/ci-operations.md "Docker Hub hooks remain the publish path"
 assert_contains docs/ci-operations.md "Rollback"


### PR DESCRIPTION
## Summary

- establish `SUPPORT.md` as the canonical PHP lifecycle policy
- mark PHP 8.0/8.1 as frozen EOL compatibility tags and document 8.2–8.5 support states
- classify Docker Hub `this` as unsupported legacy and preserve the intentional no-`latest` policy
- add GPL-2.0-only licensing, upstream attribution, contribution and private-security-reporting templates
- archive completed roadmap documents as explicitly non-authoritative history without changing image build behavior

## Safety

- no Dockerfile, hook, publisher workflow, production script, or published image changes
- no Docker Hub/GHCR push
- no legacy publisher changes
- EOL image tags and the legacy `this` tag remain untouched

## Test plan

- `./tests/test_policy_scripts.sh`
- full-file LICENSE SHA-256 integrity gate
- per-field issue-form `validations.required` structural and mutation checks
- `bash -n scripts/*.sh tests/*.sh`
- `actionlint .github/workflows/*.yml`
- `git diff --check origin/8.5...HEAD`
- CRG incremental update / change detection
- independent spec review and independent code-quality review

## Post-merge

After checks and independent reviews pass, apply and read back only the low-risk repository settings authorized in the modernization plan: read-only default workflow token, disabled Actions PR approval, private vulnerability reporting, squash-only merges, delete-branch-on-merge, wiki/projects disabled, and repository topics.
